### PR TITLE
Locations corrections

### DIFF
--- a/Localization.English.txt
+++ b/Localization.English.txt
@@ -1,359 +1,359 @@
 .,English
 quest.name,The sound of silence
-quest.description,Investigate the missing of John Mayer
+quest.description,<i>Solve the mystery of the disappearance of John, the son of your good friend, and explore the secrets of an old Baptist church from the turn of the century.</i>\n\nThe scenario is designed for 2-5 Investigators and requires tiles from the 1st edition of the Mansions of Madness. In this scenario, in most cases, the description of how to set the tokens has been abandoned. This is a deliberate move to encourage Investigators to carefully track changes in the application as well as an element of mechanics. If you noticed a token after some time, it should be placed on the board and treated as newly discovered.\n\n<b>Note: if during the game there is a command to remove all tiles from the board, the Investigator Phase starts over.</b>\n\nThe scenario is storyline oriented. It has several endings, which influence the length of the game.\n\nAny comments can be sent to the following address:https://github.com/zcaalock/SotC/issues\n\nThe scenario is created using:https://github.com/NPBruce/valkyrie
 quest.authors,zcaalock
-Token01_boy_body.button1,({action})Investigate
+Token01_boy_body.button1,({action}) Investigate
 Event02_show_body_boy.button1,Continue
-TokenInvestigators.text,Place Investigators as indicated
+TokenInvestigators.text,Place Investigators as indicated.
 Event04_investigators.button1,Continue
 Event01_show_cave_enter_tile.button1,Continue
-Event04_investigators.text,You walk through the bushes.
-Event03_take_watch.text,You see a nice engraved watch. You can examine it thoroughly using the inventory menu. \n\n (You recive ({clue}))
+Event04_investigators.text,Place Investigators as indicated.
+Event03_take_watch.text,You see a nice engraved watch. You can thoroughly examine it using the Inventory menu. \n\n (You receive 1 {clue})
 Event03_take_watch.button1,Continue
-Tokencave_shelter_show.text,The corridor continues to the east.
-Token01_boy_body.text,The boy's body was found here. After watching the scene, something glistening in the sun strikes you.
-Eventshow_cave_enter_token.text,In the distance you see the entrance carved in the rocks. It looks like an old mine.
+Tokencave_shelter_show.text,The corridor continues eastwards.
+Token01_boy_body.text,This is the place where the boy's corpse was found. After observing the scene, something glistening in the sades of sun catches your attention.
+Eventshow_cave_enter_token.text,In the distance, you see an entrance carved into the rocks. It looks like an old mine.
 TokenInvestigators.button1,Continue
 Tokencave_shelter_show.button1,Explore
-EventCave_shelter_show.text,The corridor continues for 10 meters. On the right side, you see an oil lamp and a door behind it. \n\ n (Place: {c:Tile03_cave_shelter} as indicated)
+EventCave_shelter_show.text,The corridor stretches for another 10 metres. On the right side, you can see an oil lamp and a door behind it.\n\n(Place: {c:Tile03_cave_shelter} as indicated)
 EventCave_shelter_show.button1,Continue
-Event01_show_cave_enter_tile.text,A small clearing in the middle of the forest appears before you. The land here is boggy after a recent downpour. There is a police tape around the trees. This is where the boy's body was found. \n\n (Place: {c:Tile01_Cave_entrance} as indicated)
+Event01_show_cave_enter_tile.text,You park your car in front of a small forest near the church. After walking a few hundred meters along a narrow path, in the middle of the forest appears before you. The land here is wet and boggy from a recent downpour. There is police tape around the trees. The boy's body was found here.\n\n (Place: {c:Tile01_Cave_entrance} as indicated)
 Eventshow_cave_enter_token.button1,Continue
-Event02_show_body_boy.text,The police tape encloses the place where the boy's body was found. Maybe the police missed something.
-Token01_cave_enter.button1,({action}) Open
-Token01_cave_enter.text,Entrance to the old mine. The doors are wooden and very massive but it looks like they are open
-Eventshow_cave_tile.text,You enter the old mine, from what you've heard is probably from the Civil War. It smells musty here, the air has been found for years. You can move one space inside.\n\n (Place: {c:Tile02_cave_01} as indicated)
+Event02_show_body_boy.text,The police tape indicates the location of where the boy's body was found. Maybe the police have missed something.
+Token01_cave_enter.button1,({action}) Check if the door is open.
+Token01_cave_enter.text,Entrance to the old mine. It looks as if the massive wooden doors are open.
+Eventshow_cave_tile.text,You enter the old mine. From what you've heard, it is propably a remnant of the Civil War. It smells musty here, the air has not been disturbed for years.\n\n You may move one space into the explored area.\n\n (Place: {c:Tile02_cave_01} as indicated)
 Eventshow_cave_tile.button1,Continue
-Eventshow_observe_cave.text,The tunnel disappears in the dark
+Eventshow_observe_cave.text,The tunnel disappears into the darkness.
 Eventshow_observe_cave.button1,Continue
-Eventshow_mine_end.text,In this place the tunnel is overwhelmed. You have no chance to get through.
+Eventshow_mine_end.text,In this place the tunnel appears to have collapsed. You will not be able to get through here.
 Eventshow_mine_end.button1,Continue
 Tokenend_of_tunel.button1,({action}) Investigate
-Eventshow_shelter_token.text,There is a wooden door here.
-Tokenend_of_tunel.text,The tunnel is completely overwhelmed. There is no transition
+Eventshow_shelter_token.text,On the right side, you find a wooden door.
+Tokenend_of_tunel.text,The tunnel is completely caved in. There is no way through. You can try checking the heap of rubble.\n\nObservation test {observation}.
 Eventshow_shelter_token.button1,Continue
-Tokendoor_to_shelter.text,Wooden doors are very damaged and barely hold in hinges. Judging by the footprints on the floor, someone had just passed this way recently.
+Tokendoor_to_shelter.text,Wooden doors, so badly damaged that they are barely held up by their hinges. Judging by the footprints on the floor, someone has passed this way recently.
 Tokendoor_to_shelter.button1,({action}) Enter
-Evententer_to_shelter.text,You enter a fetid and stinky room. There is an old sprawling bunk bed here.
+Evententer_to_shelter.text,You enter and are immediately hit with the fetid stink of the room.\n\nThere is an old sprawling bunk bed here.
 Evententer_to_shelter.button1,Continue
 Eventshow_lamp_token.text,The oil lamp hangs on the hook.
 Eventshow_lamp_token.button1,Continue
-Tokencave_lamp.text,The oil lamp
+Tokencave_lamp.text,An oil lamp
 Tokencave_lamp.button1,({action}) Take
-Tokenshelter_bed.text,Old stinky bed.
+Tokenshelter_bed.text,An old stinky bed.
 Tokenshelter_bed.button1,({action}) Investigate
-EventShelter_old_bed.text,It looks like the miners slept here years ago. You look at the wooden structure of the bed and see hundreds of small strokes engraved on the surface. They are grouped after 6 and one crosses the rest. \n\n (You recive ({clue})
+EventShelter_old_bed.text,It looks like the miners slept here years ago. You look at the wooden structure of the bed and see hundreds of small strokes engraved on the surface. They are grouped into 6 and one crosses the rest. \n\n (You receive 1 {clue})
 EventShelter_old_bed.button1,Continue
 Eventshelter_foodprints.text,You can see some marks on the floor.
 Eventshelter_foodprints.button1,Continue
 Tokencave_foodprints.text,Footprints and something else.
 Tokencave_foodprints.button1,({action}) Investigate
-Eventcave_footprints.text,On the floor you see footprints and a big smudged trail that stretches from the door to the small room at the end of the room. \n\n (You recive ({clue})
+Eventcave_footprints.text,On the floor you see footprints and a big smudged trail that stretches from the door to the smaller room at the end of this one. \n\n(You receive 1 {clue})
 Eventcave_footprints.button1,Continue
-Eventtime_m.text,A pile of garbage, maybe there is something interesting here.
+Eventtime_m.text,A pile of garbage; maybe there is something interesting here.
 Eventtime_m.button1,Continue
-Tokentime.text,The pile of rubbish looks like someone in a hurry trying to overcome something here
+Tokentime.text,The pile of rubbish looks like someone in a hurry tried to hide something here.
 Tokentime.button1,({action}) Investigate
-Eventtime_test.text,Under garbage you find a hatch made of metal. The whole is covered with strange symbols. It looks like a strange puzzle
-Eventtime_test.button1,Solve the puzzle
-Puzzle0.button1,Continue
-Eventtime_open.text,The passage opened
+Eventtime_test.text,Under the garbage you find a hatch made of rusted metal. The hatch is covered with strange symbols. They are very same to the ones on the watch\n\n(Only the Investigator possessing Common Item {c:QItem01_watch} can interact with the puzzle)
+Eventtime_test.button1,[I have the watch] Continue
+Puzzle0.button1,Investigate
+Eventtime_open.text,You can hear a series of tickings. The whole room seems to vibrate slightly. You are amazed to discover that some sort of a passageway has opened.
 Eventtime_open.button1,Continue
 Tokentime_enter.button1,Enter
-Eventgo_in_time.text,You start to stoop to go inside when you have a feeling that you should not go alone.
+Eventgo_in_time.text,You stoop to go inside, when you are overcome with a feeling that you should not go alone.
 Eventgo_in_time.button1,({action}) Go alone
-Eventtime_alone.text,Potykasz się i wpadasz z impetem do dziury. Czujesz na twarzy pęd zimnego powietrza...
+Eventtime_alone.text,Your impetuousness causes you to stumble and fall into the hole. You feel the rush of cold air on your face...\n\n(Remove all tiles and tokens from the board)\n\n(From now,  the action takes place from the perspective of the Investigator who entered the secret passage. Other Investigators cannot perform any actions.)
 Eventtime_alone.button1,Continue
-Eventwait_for_friends.text,You call your companions. After a while they come, try to convince them to come in with you.
-Eventwait_for_friends.button1,({action}) You enter together
-Tokentime_enter.text,The passage is inclined and leads underground. You feel a cold breeze and some kind of ionized air.
+Eventwait_for_friends.text,You call your companions. After a while they approach and you try to convince them to come with you.
+Eventwait_for_friends.button1,({action}) Enter together.
+Tokentime_enter.text,The passage leads underground. You feel a cold breeze and a strange sensation, like the air is ionized.
 Eventgo_in_time.button2,Wait for companions
-Eventall_go_in_time.text,You are passing through the darkness, feeling the cold wind on your faces ... \n\n (remove all tiles and markers from the board)
+Eventall_go_in_time.text,You are passing through the darkness, feeling the cold wind on your faces...\n\n(Remove all tiles and tokens from the board)
 Eventall_go_in_time.button1,Continue
 Eventwait_for_friends.button2,Don`t go in
-Eventpast_start_event.text,... you enter the small, bright room for hard tiles with impetus. Each of you receives 2 damage cards ({agility} prevents)
+Eventpast_start_event.text,... you enter the small, bright room and hit the tiles hard.\n\n(Each Investigator suffers 2 facedown damage ({agility} negates))
 Eventpast_start_event.button1,Continue
-Eventpast_show_items_torture_room.text,You hit the floor. Trying to get up, you can see the passage from which you fell and the door on the other side. In the middle of this small room there is a bed with straps. \n\n (Place: {c:Tilepast_shelter} as indicated)
+Eventpast_show_items_torture_room.text,Trying to get up, you throw a glance at the whole room. On the one hand, you see a passage through which you've just fallen a moment ago. You are in a small room covered with white tiles. It's clean and bright here. You are surprised by a bed with leather straps standing in the middle of the room.\n\n (Place: {c:Tilepast_shelter} as indicated)
 Eventpast_show_items_torture_room.button1,Continue
-Tokengo_to_future.text,The transition from which you fell out.
+Tokengo_to_future.text,The passage from which you fell out.
 Tokengo_to_future.button1,Go through the passage
-Tokenpast_doors1.text,Door. You wonder where they lead
+Tokenpast_doors1.text,A door. You wonder where it leads.
 Tokenpast_doors1.button1,Continue
-Tokentorture_bed.text,A bed with straps
+Tokentorture_bed.text,A bed with heavy leather straps.
 Tokentorture_bed.button1,({action}) Investigate
-Eventtorture_bed.text,There are traces of blood on the bed. It is lightly burnt on one side. \n\n (You recive ({clue})
+Eventtorture_bed.text,Looking at the bed you can see traces of blood. Additionally, it turns out that it is slightly burnt on one side. Next to the bed, there is a device with cables attached to the headband.\n\n (You receive 1 {clue})
 Eventtorture_bed.button1,Continue
-Eventgo_to_future_.text,It overwhelms you that you should not go in without your friends.
+Eventgo_to_future_.text,A feeling overwhelms you, you should not go in without your friends.
 Eventgo_to_future_.button1,({action}) Go alone
 Eventgo_to_future_.button2,({action}) Go with companions
-Eventgo_to_future_alone.text,You go to the passage alone and once again you are running fast through the void
+Eventgo_to_future_alone.text,You enter the passage alone and once again you are running fast through the void.
 Eventgo_to_future_alone.button1,Continue
-Eventgo_to_future_all.text,You jump into the passage and again speed through the void ...
+Eventgo_to_future_all.text,You jump into the passage and again speed through the void...
 Eventgo_to_future_all.button1,Continue
 Eventback_in_future.text,You fall into a pile of garbage. After a while, you manage to dig up and stand on your feet. You look around and see the same room in the mine you first came from. You look back and see that the transition has disappeared. You touch desperately every piece of floor and wall, you call your friends but there is no response. After a few minutes, resigned you decide to give up.
 Eventback_in_future.button1,Continue
-Tokenwatch_from_past.text,Something is lying on the floor.
+Tokenwatch_from_past.text,Something small is lying on the floor.
 Tokenwatch_from_past.button1,({action}) Investigate
-Eventwatch_from_past.text,"It's an old pocket watch. It looks just like the one you found in the place where the boy's body was. Only this watch is much older, it's rusty and it has a broken window ... Right now, it's the same watch, it has an engraving on the back with the inscription ""for Evan 1881"". It is impossible..."
+Eventwatch_from_past.text,"It's an old pocket watch. It looks just like the one you found in the place where the boy's body was. Only this watch is much older! It's rusty and it has a broken face... Wait a moment... It's the same watch! It has an engraving on the back, an inscription - ""for Evan 1881"". How is this possible...?"
 Eventwatch_from_past.button1,Continue
-Tokenmessage_from_past.text,Old bed. You think it looks a bit different.
+Tokenmessage_from_past.text,An old bed. You think it looks a bit different then before.
 Tokenmessage_from_past.button1,({action}) Investigate
-Eventmessage_from_past.text,The dashes on the bed disappeared. That surprised and disturbed you very much. You're starting to wonder if you're crazy. You receive 2 cards of horror. After a closer look at the wooden structure, you can see the inscription engraved on one of the boards. The inscription is old but you manage to read it.
+Eventmessage_from_past.text,Although the bed is still covered with dashes as before, after a closer look at the wooden structure, you will find that next to it there is a disturbing inscription engraved on one of the planks. Although it looks old, it may be possible to read it.
 Eventmessage_from_past.button1,Continue
-Eventmessage_from_past_1.text,"You can hardly read the message: ""w..nev.r you re.. ..is, .ave me."". You have no idea what it means."
+Eventmessage_from_past_1.text,"You can hardly read the message: ""w.nev.r you re.. ..is, .ave me"".\n\n(Suffer 2 Horror and receive 1 {clue})"
 Eventmessage_from_past_1.button1,Continue
 Tokenend_game_alone.button1,({action}) Exit
 Eventend_game_03_alone.button1,Continue
 Eventgo_to_future_.button3,Wait for companions
-Event_back_in_future_all.text,Awkwardly you leave in the same stinking place in the mine you entered a few hours ago. Rubbish is scattered all around
+Event_back_in_future_all.text,Awkwardly you exit in the same stinking place in the mine you entered a few hours ago. Rubbish is scattered all around.
 Event_back_in_future_all.button1,Continue
 Tokenend_game_all.text,Exit to the outside (end of the game)
-Tokenend_game_all.button1,({action})Continue
-Eventend_game_all.text,You are leaving the mine. Despite the many months of investigation, you fail to explain the death of the boy found or find John. For the rest of your life, each of you wonders what actually happened on this rainy day when you started the investigation. Was this really happening at all?
+Tokenend_game_all.button1,({action}) Continue
+Eventend_game_all.text,You are leaving the mine. Despite the many months of investigation, you have failed to explain the death of the boy or find John.\n\n For the rest of your life, each of you wonders what actually happened on this rainy day when you started the investigation.\n\nHad this really happening at all?
 Eventend_game_all.button1,Continue
 Tokenend_game_alone.text,The passage leads outside. (End of the game)
-Tokenpast_shelf_in_shelter.text,Shelf with sort of items
+Tokenpast_shelf_in_shelter.text,You see a bunk bed. Fresh paint and dirty smelly bedding suggest that from time to time someone sleeps here.
 Tokenpast_shelf_in_shelter.button1,({action}) Investigate
 Eventpast_shelf_in_shelter.button1,Continue
-Eventpast_shelf_in_shelter_all.text,You feel enormous pain in the region of the occiput, and then it makes you dark in front of your eyes ... You get stunned and lose your turn.
-Eventpast_end_game_alone.text,"You feel enormous pain in the region of the occiput, and soon afterwards you get dark in front of your eyes ... You wake up after a while in the same place. The front door is barricaded, you can not open it. You scour the entire room in search of a way out. Unfortunately, it looks like you're stuck here. Fortunately, a lot of food and water is stored in the next room. After a few hours the oil lamp falls out and you stay in total darkness. You lose a sense of time, you try to count the days you spent here with burning dashes in wood. After an indefinite period, you have inscribed ""whenever you read this, save me."" You fall asleep exhausted and you never wake up again."
-Eventpast_end_game_alone.button1,Continue (End of the game)
-Eventgo_to_future_disapear.text,The transition disappears
-Eventpast_end_game_alone0.text,You are leaving the mine. Despite the many months of investigations, you fail to find John, and what's most sad about your commons is also missing. For the rest of your life, each of you wonders what actually happened on this rainy day when you started the investigation. Was this really happening at all?
+Eventpast_shelf_in_shelter_all.text,You feel enormous pain in the back of your heads and your vision goes dark ...\n\n(All Investigators become Stunned and any remaining actions for this turn are lost).
+Eventpast_end_game_alone.text,"You feel enormous pain in the back of your head, and soon afterwards it get dark in front of your eyes ... \nYou wake up after a while in the same place. The front door is barricaded and you can not open it. You scour the entire room in search of a way out. Unfortunately, it looks like you're stuck here.\n Fortunately, a lot of food and water is stored in the next room. After a few hours the oil lamp falls out and you as stuck here... in total darkness.\nYou lose all sense of time, you try to count the days you spent here with burnt dashes in wood. After an indefinite period, you have inscribed ""whenever you read this, save me.""\nYou fall asleep agonally exhausted.\n\n(If any tokens are left on {c:Tilepast_shelter}, remove them from board)"
+Eventpast_end_game_alone.button1,Continue
+Eventgo_to_future_disapear.text,You were surprised to find that the passage had disappeared. In front of you, you see a bare wall lined with tiles.
+Eventpast_end_game_alone0.text,Moments after the Investigator jumped himself into a strange passage, it closes, leaving behind a wall covered with dirty, destroyed tiles.\n\n(Place: {c:Tile01_Cave_entrance}, {c:Tile02_cave_01}, {c:Tile03_cave_shelter} as indicated)
 Eventpast_end_game_alone0.button1,Continue
-Eventthe_end.text,The End
+Eventthe_end.text,The End.
 Eventthe_end.button1,Continue
-Eventpast_shelf_in_shelter.text,You start to look closely at the things on the shelf, there are various religious books. One of them interested you, it is bound in strange skin, it looks a bit like human. You reach out to take her when suddenly ...
+Eventpast_shelf_in_shelter.text,You start to look closely at the things on the shelf. There are various religious books. One of them peaks your interest as it is bound in a strange skin. It looks a bit human. You reach out to take it when suddenly ...
 Eventpast_shelf_in_shelter_all.button1,Continue
 Spawncultist.button1,Continue
-Eventpast_mine_show.text,Behind the opponent you can see a dimly lit room. It looks like a cave or mine. \n\n (Place: {c:Tile03_cave_shelter} as indicated)
+Eventpast_mine_show.text,Behind the opponent you can see a dimly lit room. It looks like a cave or a mine. \n\n (Place: {c:Tile03_cave_shelter} as indicated)
 Eventpast_mine_show.button1,Continue
 Tokenpast_mine_show_left.text,The corridor continues in this direction.
 Tokenpast_mine_show_left.button1,Explore
 Eventpast_mine_show2.text,The tunnel leads straight and then turns left. Considering the cold air that flows from this direction, there must be an exit. \n\n Place: {c:Tile02_cave_01} as indicated)
 Eventpast_mine_show2.button1,Continue
-Tokenpast_mine_exit.text,Doors outside. They're closed, you can not open them.
+Tokenpast_mine_exit.text,The door to the outside. They're closed, you can not open them.
 Tokenpast_mine_exit.button1,({action}) Investigate
-Eventpast_show_outside.text,Through the crack in the door you see a clearing surrounded by thick forest. \n\n You receive {clue}. \n\n (Place: {c:Tile01_Cave_entrance} as indicated)
+Eventpast_show_outside.text,Through the crack in the door you see a clearing surrounded by thick forest. \n\n(You receive 1 {clue}) \n\n (Place: {c:Tile01_Cave_entrance} as indicated)
 Eventpast_show_outside.button1,Continue
 Tokenpast_mine_show_right.text,The tunnel begins to descend down here.
 Tokenpast_mine_show_right.button1,Explore
-Eventpast_mine_show_right.text,The tunnel is poorly enlightened and runs steeply down. \n\n (Place: {c:Tilepast_mine_tuner_right} as indicated)
+Eventpast_mine_show_right.text,The tunnel is poorly lit and runs downwards on a steep decline. \n\n (Place: {c:Tilepast_mine_tuner_right} as indicated)
 Eventpast_mine_show_right.button1,Continue
-Eventpast_mine_tunel_right_items_show.text,On the ground you can see rope pulling everywhere, or something that reminds you. To the right are heavy metal doors.
+Eventpast_mine_tunel_right_items_show.text,On the ground you can see a bundle of ropes pulled tight, or something that reminds you of that. To the right are heavy metal doors.
 Eventpast_mine_tunel_right_items_show.button1,Continue
-Tokenpast_mine_right_tunnel_dynamite.text,Plontan of strange thin ropes.
+Tokenpast_mine_right_tunnel_dynamite.text,Bundle of strange thin ropes.
 Tokenpast_mine_right_tunnel_dynamite.button1,({action}) Investigate
-Eventpast_dynamite.text,To your surprise, you discover that these are sticks of dynamite attached to beams holding the ceiling. \n\n Recive ({clue}).You can take 1 stick of dynamite with you \n\n Test: {observation}
+Eventpast_dynamite.text,To your surprise, you discover that these are sticks of dynamite attached to beams holding up the ceiling. \n\n(You receive 1 {clue}).\n\n(You may take 1 Dynamite Common Item. Observation test {observation})
 Eventpast_dynamite.button1,Take
 Tokenpast_tunel_right_end.button1,Explore
-Tokenpast_tunel_door.text,Heavy metal door. To open them you need a silver key.
+Tokenpast_tunel_door.text,Heavy metal door. To open it you need a silver key.
 Tokenpast_tunel_right_end.text,The tunnel continues in this direction.
 Tokenpast_tunel_door.button1,({action}) Open
-Eventpast_tunel_door_open.text,You turn the key in the lock, it fits perfectly. You open the door with a big rasp ..
+Eventpast_tunel_door_open.text,You turn the key in the lock. It fits perfectly. You open the door and it groans in response ...
 Eventpast_tunel_door_open.button1,Continue
 Eventpast_boy_room_reveal.text,... You see a dark room. \n\n (Place: {c:Tilepast_boy_room} as indicated)
 Eventpast_boy_room_reveal.button1,Continue
-Eventpast_boy_found.text,There is a figure on the bed. After careful acceptance, you find that it's little John. You can see that it is in poor condition but at least it lives.
+Eventpast_boy_found.text,There is a figure on the bed. After a careful inspection, you find that it's little John. You can see that he is in poor condition but at least he is alive.
 Eventpast_boy_found.button1,Continue
-TokenJohn.text,You approach the child and see how slowly he opens his eyes.
-TokenJohn.button1,({action}) How are you?
-Eventtake_john.text,You take John in your arms. From now until you leave John you can only do one action per turn.
+TokenJohn.text,You see a 10-years old boy. When you approach him, he slowly opens his eyes.
+TokenJohn.button1,({action}) Have a talk
+Eventtake_john.text,You take John in your arms.\n\n(From now until you save John you can only do one action per turn)
 Eventtake_john.button1,Continue
-Eventend_game_alone_with_john.text,You leave the mine. Your friends have never found one, even though you've spent many months searching for them. You also failed to solve the mystery of the murder of a boy found in front of the mine. All the time you are not disturbed by the fact that it seems to you that it was the same boy whom you saw there among this secret sect. He was wearing the same clothes. But how is it possible, how he did not live ... You will not forgive yourself for the rest of your life that you left your friends there. But did it really happen? The only thing that comforts you is that John is safe. Recently, you visit the sanatorium less frequently ... you look thoughtfully through the barred window as the sun sets over Arkham.
 Eventend_game_question_john.text,Is John with you?
+Eventend_game_alone_with_john.text,You leave the mine. Your have never found your friends, even though you had spent many months searching for them. You will not forgive yourself for the rest of your life that you left your friends there. How could you...\n You have also failed to solve the mystery of the murder of the boy found in front of the mine. Since then, you have this distressing  feeling that it may have been the same boy whom you saw on the altar among the followers of the secret sect. He was wearing the same clothes. But how was it be possible? He was dead, right...?\n The only thing that comforts you is that John is safe. Unfortunately, he has been visiting you less and less often recently, while you're watching the sun setting over Arkham while you sit alone in a white room with barred windows.
 Eventend_game_question_john.button2,No
 Eventend_game_alone_with_john.button1,Continue
 Eventend_game_all_without_john.button1,Continue
-Eventend_game_alone_without_john.text,You leave the mine. Your friends have never found a place, although you've spent many months searching for them. You also failed to solve the mystery of the boy's murder. You did not forgive for the rest of your life that you left them there. Most regret for John, you often think of him lying down and looking through the barred window of the Arkham Asylum.
+Eventend_game_alone_without_john.text,You leave the mine. Your have never found your friends, even though you had spent many months searching for them. You have also failed to solve the mystery of the murder of the boy found in front of the mine. You have never forgive yourself for the rest of your life leaving all of them there...\nBut yours biggest regret is John, the small boy whom you couldn't help finding him way to his heartbroken mother who commited suicide at the end... You often think of him and Jane lying down on your strapped bed and looking through the window on the darkest starless sky across bars of the Arkham Asylum.
 Eventend_game_alone_without_john.button1,Continue
-Eventend_game_all_with_john.text,You are leaving the mine. Unfortunately, you failed to solve the mystery of the murder of a boy found in front of the mine. All the time you are not disturbed by the fact that it seems to you that it was the same boy whom you saw there among this secret sect. He was wearing the same clothes. But how is it possible, how he did not live ... But did it really happen? Fortunately, John is safe.
+Eventend_game_all_with_john.text,You are leaving the mine. Unfortunately, you have also failed to solve the mystery of the murder of the boy found in front of the mine. Since then, you have this distressing  feeling that it may have been the same boy whom you saw on the altar among the followers of the secret sect. He was wearing the same clothes. But how was it be possible? He was dead, right...?\nFortunately, John is safe, although he suffered trauma after the events in the mine and has never been the same since then.
 Eventend_game_all_with_john.button1,Continue
-Event_watch.text,"You watch the watch, it is done very carefully, the glossy metal is thoroughly polished. There is an engraving on the back with the inscription: ""for Evan 1881"" It's pretty good for a 40 year old watch."
+Event_watch.text,"You study the watch very carefully, the glossy metal is thoroughly polished. There is an engraving on the back, with the inscription: ""for Evan 1881"" It's in a pretty good condition for a 40-years old watch."
 Event_watch.button1,Continue
-Eventshow_watch_from_past.text,Something shimmers on the floor.
+Eventshow_watch_from_past.text,Looking around the room, you see something shimmering on the floor.
 Eventshow_watch_from_past.button1,Continue
-Eventpast_dynamite.button2,Fail
-Eventtake_dynamite.text,You're able to untangle one dynamite stick.
+Eventpast_dynamite.button2,Failure
+Eventtake_dynamite.text,You are able to untangle one of the sticks of dynamite.\n(You receive: {c:QItempast_dynamite} Common Item)
 Eventtake_dynamite.button1,Continue
 Eventtake_dynamite_fail1.text,You failed to disentangle the dynamite from this Gordian knot.
 Eventtake_dynamite_fail1.button1,Continue
-Tokendynamite_after_fail.text,You see the tangled sticks of dynamites. You can try to remove the dynamite again. \n\n\ Test {agility}
+Tokendynamite_after_fail.text,You see the tangled sticks of dynamite. You can try to remove the dynamite again. \n\nTest agility {agility}.
 Tokendynamite_after_fail.button1,({action}) Take
-Tokendynamite_after_fail.button2,Fail
-Eventtake_dynamite_2_fail.text,You are trying unsuccessfully to extract the stick of dynamite from a tangle of kerps soaked in kerosene. It's quite unkindly you got a stupid idea to think about lighting this place with an oil lamp. Unfortunately, it fell out of your hands and the flame spilled over half of the tunnel ...
+Tokendynamite_after_fail.button2,Failure
+Eventtake_dynamite_2_fail.text,You are try, but are unsuccessful at extracting the stick of dynamite from a tangle of kerps soaked in kerosene. You have a mad and stupid notion to light this place with the oil lamp. Unfortunately, it fell from your hands and the flame spilled across half of the tunnel. To your misfortune, it has spread so quickly that you are not able to extinguish it....
 Eventtake_dynamite_2_fail.button1,Continue
-Eventfire_event_start.text,The flames began spreading very quickly through the dusty floor and spider webs on the walls. You instinctively understand that you do not have much time to escape.
+Eventfire_event_start.text,The flames has begun spreading very quickly along the dusty floor and across the spider webs on the walls.\nYou instinctively know, that you do not have much time to escape!
 Eventfire_event_start.button1,Continue
-Eventfire_endin_begin.text,The fire is spreading rapidly, it will soon become dynamite. You must escape ... Each investigator receives 1 card of horror.
+Eventfire_endin_begin.text,The fire is spreading rapidly, it will soon reach the dynamite. You must run!\n\n(Each investigator suffers 1  horror)
 Eventfire_endin_begin.button1,Continue
-Eventfire_ending_mieddle.text,From the depths of the tunnel, you hear some screams. A cry comes from behind the closed door. You think it's the child's voice but you try not to realize it. Everything begins to burn like a torch. The fire reached the fuse and in a moment everything would explode. You have the last chance to escape.
+Eventfire_ending_mieddle.text,From the depths of the tunnel, you hear screams. A cry comes from behind the closed door. You think it's a child's voice but you would rather it not to be true.\nEverything begins to burn like a torch. The fire will soon reach the fuse and in a moment everything will explode.\n\n(This is your  last chance to escape
 Eventfire_ending_mieddle.button1,Continue
-Eventexplode.text,A violent explosion throws you against the wall. Have you managed to reach the room where there is a bed with straps?
+Eventexplode.text,A violent explosion throws you against the wall. Have you managed to reach the room with the bed that has leather straps?
 Eventexplode.button1,Yes
 Eventexplode.button2,No
-Eventall_dead.text,The End. Everyone is dead
+Eventall_dead.text,The End. \n\nEveryone is dead.
 Eventall_dead.button1,Continue
-Tokenblock.text,The passage is blocked
+Tokenblock.text,The passage is blocked.
 Tokenblock.button1,Continue
-Eventafter_explode.text,You survived the explosion. The transition is completely blocked.
+Eventafter_explode.text,You have survived the explosion. The passage is completely blocked.
 Eventafter_explode.button1,Continue
-Eventpast_end_john.text,You have a feeling that it will be better to get out of here as soon as possible. You hear a strange sound, you are shivering on your back. Each Investigator recive one facedown horror
+Eventpast_end_john.text,You have a feeling that it will be better to get out of here as soon as possible. You hear a strange sound, and the hairs on the back of your neck stand up on end. \n\n(Each Investigator receive 1 facedown horror)
 Eventpast_end_john.button1,Continue
 Eventpast_end_john_1.button1,Continue
-Eventpast_end_john_1.text,You hear a growing roar coming from the tunnel in the east. You feel growing fear. Each Investigator recive one facedown horror
-Eventpast_end_john_2.button1,Przycisk1
+Eventpast_end_john_1.text,You hear a growing roar coming from the east side of the tunnel. Fear wells up inside you, growing with each moment.\n\n(Each Investigator suffers 1 facedown horror)
+Eventpast_end_john_2.button1,Continue
 Eventpast_end_john_2.text,At the bottom of the tunnel appears a huge, hooded figure.
-Eventpast_end_john_3.text,Posta seems to have some strange sounds, as if it were some unknown language. He starts to walk along the corridor.
+Eventpast_end_john_3.text,Posta seems to speak some strange sounds, as if it were some unknown language. He starts to walk along the corridor towards you.
 Eventpast_end_john_3.button1,Continue
-Eventspawndagon.button1,Przycisk1
-Eventpast_end_john_4.text,A huge ball of fire passes through the corridor.
+Eventspawndagon.button1,Continue
+Eventpast_end_john_4.text,The figure releases from his hands  a huge fireball and throws it in your direction. You barely avoid a collision with the threat, but you can feel his burning heat on your skin.
 Eventpast_end_john_4.button1,Continue
-Eventpast_ednding_middle_john.text,From the depths of the tunnel, you hear some screams. The monster's robe lights up with fire. Everything begins to burn like a torch. The fire reached the fuse and in a moment everything would explode. You have the last chance to escape.
+Eventpast_ednding_middle_john.text,Behind your back, from the depths of the tunnel, you hear a terrifying scream. The monster's robe lights up with fire. Everything begins to burn. The fire will reach the fuse soon and in a moment everything will explode!\n\n(This is your last chance to escape)
 Eventpast_ednding_middle_john.button1,Continue
 Eventend_game_question_john.button1,Yes
-Eventend_game_all_without_john.text,You are leaving the mine. You failed to solve the mystery of the boy's murder. \n\n You often think about it lying down and looking through the barred window of the Arkham Asylum.
+Eventend_game_all_without_john.text,You are leaving the mine. You failed to solve the mystery of the boy's murder.\n\n You often think about it when you are lying down, looking through the barred window of the Arkham Asylum.
 Tokenpast_papers.text,A pile of newspapers.
 Tokenpast_papers.button1,({action}) Read
-Eventpast_newspaper_president.button1,Read another one
-Eventpast_newspaper_boy.text,September 26, 1901 (Thursday). This is the 7th missing child in the last 3 months. The wanted boy is Evan McCormic, 10 years old, the son of a farmer. He did not return home after working on collecting corn. The city authorities are concerned about the latest disappearances. Sheriff Ratman has set a $ 500 reward for finding a boy. A local Baptist group is organizing an evening meeting on September 20, during which you will be able to support the missing boy's family. (You recive ({clue}))
-Eventpast_newspaper_president.text,October 29, 1901 (Wednesday). President William McKinley's shot. During the meeting, he was shot by Leon Czolgosz, an American of Polish origin who believed that McKinley was guilty of widespread social injustice. The president received two shots in the stomach and chest and was quickly transferred to a nearby hospital. After dressing the abdominal wound, the doctors hope that McKinley will recover ...
-Eventpast_newspaper_boy.button1,Read another one
+Eventpast_newspaper_president.button1,Read another one.
+Eventpast_newspaper_boy.text,September 26, 1901 (Thursday). This is the 7th missing child in the last 3 months.\nThe wanted boy is Evan McCormic, 10 years old, the son of a farmer. He did not return home after his work collecting corn.\nThe city authorities are concerned about the latest disappearances. Sheriff Ratman has set a $500 reward for finding the boy.\nA local Baptist group is organizing an evening meeting on September 20, during which you will be able pledge your support to the missing boy's family.\n\n (You receive 2 {clue})
+Eventpast_newspaper_president.text,October 29, 1901 (Wednesday). President William McKinley's shot.\nDuring the meeting, he was shot by Leon Czolgosz, an American of Polish origin who believed that McKinley was guilty of widespread social injustice.\nThe president received two shots in the stomach and chest and was quickly transferred to a nearby hospital. After dressing the abdominal wound, the doctors hope that McKinley will make a full recovery ...
+Eventpast_newspaper_boy.button1,Read another one.
 Eventpast_newspaper_menu.text,Choose
-Eventpast_newspaper_menu.button1,President shot..
-Eventpast_newspaper_menu.button2,Missing child..
-Eventpast_newspaper_menu.button3,The end of the world
-Eventpast_newspaper_end_of_world.text,"Social tensions are growing due to the turn of the century. The pastor of the local Baptist church urges everyone to abandon their sins and give back what is the most valueble for them to god. <i>""The day of final judgment is approaching, who will not understand this will die in the fire of hell ... ""</i> said pastor Carl Panzram."
+Eventpast_newspaper_menu.button1,President shot...
+Eventpast_newspaper_menu.button2,Missing child...
+Eventpast_newspaper_menu.button3,The end of the world...
+Eventpast_newspaper_end_of_world.text,"Social tensions are growing due to the turn of the century.\nThe pastor of the local Baptist church urges everyone to abandon their sins and give their most valuable possessions to god. <i>""The day of final judgment is approaching! Those who do not understand this will die in the fires of hell...""</i> said pastor Carl Panzram."
 Eventpast_newspaper_end_of_world.button1,Read on
-Tokenopen_secret_to_church.text,You see freshly formed soil and footprints all around. ({observation})
+Tokenopen_secret_to_church.text,You see freshly formed soil and footprints all around.\n\nObservation test {observation}.
 Tokenopen_secret_to_church.button1,Continue
-Eventsecret_to_church_reveal.text,You discover with astonishment the flap that leads to the dark tunnel
+Eventsecret_to_church_reveal.text,You discover with astonishment a flap that leads to a dark tunnel.
 Eventsecret_to_church_reveal.button1,Continue
 Tokentunel_to_church.text,Entrance to the tunnel.
 Tokentunel_to_church.button1,({action}) Enter
-Eventpast_tunel_end.text,The tunnel runs several meters to the east. On the left you can see a passage covered with stones and boarded up. At the end of the tunnel there is a door. \n\n (Place: {c:Tilepast_tunel_end} as indicated)
+Eventpast_tunel_end.text,The tunnel runs several meters to the east. On the left you can see a passage covered with stones which is boarded up. At the end of the tunnel there is a door. \n\n (Place: {c:Tilepast_tunel_end} as indicated)
 Eventpast_tunel_end.button1,Continue
-Tokenshow_blocked_doors.text,Boarded crossing. If only to have something to undermine these boards ...
+Tokenshow_blocked_doors.text,Boarded passage. If only to have something to remove these boards ...
 Tokenshow_blocked_doors.button1,Continue
-Eventopen_blocked_doors.text,It seems that the pickaxe will be able to open this passage
-Eventopen_blocked_doors.button1,({action}) Open the passage with pickaxe
-Eventopen_blocked_doors.button2,Don`t have pickaxe
-Eventreveal_blocked_room.text,The wall made of planks and stones collapses, revealing a small dark room. There are many stinking barrels and mining tools in it. You can see the chest from the side. \n\n (Place: {c:Tilesecret_room} as indicated)
+Eventopen_blocked_doors.text,You think if you use the pickaxe, you may be able to open this passage!
+Eventopen_blocked_doors.button1,({action}) Open the passage with pickaxe.
+Eventopen_blocked_doors.button2,Don't have pickaxe
+Eventreveal_blocked_room.text,The wall collapses, planks and stones falling to reveal a small dark room. There are many stinking barrels and mining tools in it. You can also see a chest to one side. \n\n (Place: {c:Tilesecret_room} as indicated)
 Eventreveal_blocked_room.button1,Continue
-Tokenshotgun_chest.text,You see a large, solidly built metal chest. It is closed with a combination lock.
-Tokenshotgun_chest.button1,({action}) Try to open
-Eventspawn_monster_stairs.text,Reading the newspaper interrupts the steps. A figure comes through the door from the outside. She looks very surprised.
-Eventtake_shotgun.text,The chest opens and you can see the shotgun inside. \n\n (You revice: {c:QItemshot_gun})
+Tokenshotgun_chest.text,A large, solidly built metal chest. It is locked up tight. A combination lock hangs from it.
+Tokenshotgun_chest.button1,({action}) Try to open.
+Eventspawn_monster_stairs.text,You are interrupted from reading the rest of the newspaper by footsteps. A hudded figure comes through the door from the outside and he looks very surprised to see you.
+Eventtake_shotgun.text,The chest opens and you can see a shotgun inside. \n\n (You revice: {c:QItemshot_gun})
 Puzzleopen_chest.button1,Check
 Eventtake_shotgun.button1,Continue
-TokenMiddle_room.text,You see a small wooden door at the end of the tunnel
+TokenMiddle_room.text,A wooden door at the end of the tunnel.
 TokenMiddle_room.button1,({action}) Open
-Eventopen_middle_door.text,The door opens with a loud crack. You see a wooden staircase that leads down to a large room. \n\n (Place: {c:Tilemieddle_room} as indicated)
+Eventopen_middle_door.text,The door opens with a loud creak. You see a wooden staircase that leads down into a large room. \n\n (Place: {c:Tilemieddle_room} as indicated)
 Eventopen_middle_door.button1,Continue
-Eventmiddle_room_show.text,At the bottom, there is a door next to the stairs, and next to it is a table with some objects.
+Eventmiddle_room_show.text,At the bottom of the steps is a door. Next to it, you see a table with some objects on it.
 Eventmiddle_room_show.button1,Continue
-Tokendoor_to_secret_church.text,Doors lead north.
+Tokendoor_to_secret_church.text,Door leads north.
 Tokendoor_to_secret_church.button1,({action}) Open
-Eventopen_room_to_secret_church.text,The door opens and you see a room that looks like a pumping station. The pipes protrude from the walls and the floor is damp. There is a smell of mold and moldy wood in the air. \n\n (Place: {c:Tilesecret_passage} as indicated)
+Eventopen_room_to_secret_church.text,The door opens and you see a room that looks like a pumping station. The pipes protrude from the walls and the floor is damp. There is the musty smell of moldy wood in the air. \n\n (Place: {c:Tilesecret_passage} as indicated)
 Eventopen_room_to_secret_church.button1,Continue
-Tokenitems_in_middle_room.text,There are several items on the table
+Tokenitems_in_middle_room.text,There are several items on the table.
 Tokenitems_in_middle_room.button1,({action}) Investigate
-Eventitems_in_middle_room.text,"There is a thick book on the table. You open it. On the first page is an inscription: ""Journal of Works 1850-1855. Copper Mine"" In the middle there are tables with names, dates and quantity of extracted ore. (You recive ({clue})) \n\n and {c:QItemitem_in_middle_room}"
+Eventitems_in_middle_room.text,"There is a thick book on the table. You open it. On the first page is an inscription: ""Journal of Works 1850-1855. Copper Mine"" In the middle there are tables with names, dates and quantity of extracted ore. (You receive 1 {clue} and {c:QItemitem_in_middle_room})"
 Eventitems_in_middle_room.button1,Continue
-Eventmiddle_room_show1.text,In the further part of the room, you see two doors and a pile of newspapers against the wall.
+Eventmiddle_room_show1.text,In the other section of the room, you see two doors and a pile of newspapers against one wall.
 Eventmiddle_room_show1.button1,Continue
 Tokenenter_to_church_corridor.text,The door leading to the east.
 Tokenenter_to_church_corridor.button1,({action}) Open
-Eventcorridor_to_church_reveal.text,The door opens. You see a pretty staircase lined with a red carpet. A steep staircase leads up, at the end you can see another door. \n\n (Place: {c:Tilestairs_up} as indicated)
+Eventcorridor_to_church_reveal.text,The door opens. You see a pristine staircase lined with a red carpet. A steep staircase leads up. At the end you can see another door. \n\n (Place: {c:Tilestairs_up} as indicated)
 Eventcorridor_to_church_reveal.button1,Continue
 Tokenpast_church_enter.text,Wooden, decorated door.
 Tokenpast_church_enter.button1,({action}) Investigate
 Tokenpast_church_enter.button2,({action}) Enter
-Tokenpick_axe_room.text,Wooden door. They drive south.
+Tokenpick_axe_room.text,Wooden door. It leads south.
 Tokenpick_axe_room.button1,({action}) Open
-Eventaxe_room_reveal.text,After opening the door you see a narrow room. Two oil lamps illuminate large rectangular containers. \n\n At the end of the room, you see a man who is bending over something (Place: {c:Tileaxe_room} as indicated)
+Eventaxe_room_reveal.text,After opening the door you see a narrow room. Two oil lamps illuminate several large rectangular containers. \n\n At the end of the room, you see a man bending over something (Place: {c:Tileaxe_room} as indicated)
 Eventaxe_room_reveal.button1,Continue
 Tokenpick_axe.text,You see three metal containers.
 Tokenpick_axe.button1,({action}) Investigate
 Eventspawn_monster_stairs.button1,Continue
-Eventmonster_stairs_menu.text,"<i>""What's going on here, how did you get here, who are you?""</i> - the man accuses you with a hail of questions"
+Eventmonster_stairs_menu.text,"<i>""What's going on here, how did you get here, who are you?""</i> - the man accuses you with a hail of questions."
 Eventmonster_stairs_menu.button1,Attack him
-Eventmonster_stairs_menu.button2,I'm a detective
-Eventmonster_stairs_menu.button3,I'm a miner
-Eventmonster_stairs_menu.button4,I'm from church
-Eventaxe_take.text,The containers look like coffins. They are empty but you have the impression that it may soon change. Between the containers you see a pickaxe \n\n You recive ({clue}) and {c:QItemaxe}
+Eventmonster_stairs_menu.button2,I'm a detective.
+Eventmonster_stairs_menu.button3,I'm a miner.
+Eventmonster_stairs_menu.button4,I'm from church.
+Eventaxe_take.text,The containers look like coffins. They are empty but you have the impression that, that may soon change. Between the containers you see a pickaxe. \n\n(You receive 1 {clue} and the {c:QItemaxe} Common Item)
 Eventaxe_take.button1,Continue
-Eventpast_newspaper_end_of_world.button2,Read other one
+Eventpast_newspaper_end_of_world.button2,Read other one.
 Eventpast_newspaper_menu.button4,Cancel
 Eventpast_newspaper_president.button2,Cancel
 Eventpast_newspaper_boy.button2,Cancel
-Spawnspawn_staits_monster.text,"You see a figure in front of you that has changed terribly. <i>""I think I found another victim on the day of atonement ..""</i>"
+Spawnspawn_staits_monster.text,"You see a figure in front of you that has changed terribly. <i>""I think I found another victim on the day of atonement ...""</i>"
 Spawnspawn_staits_monster.button1,Continue
 Eventstaris_monster_defeat.text,Monster dies
 Eventstaris_monster_defeat.button1,Continue
-Eventi_detective.text,"<i>""Detective, you say? You probably want to know who I am ""</i> - man answers, slowly raising his right hand."
+Eventi_detective.text,"<i>""Detective, you say? You probably want to know who I am...""</i> - man answers, slowly raising his right hands."
 Eventi_detective.button1,Continue
-Eventi_miner_dynamite.button1,Give him dynamite (if you have it with you)
-Eventi_miner_dynamite.button2,I don`t have
-Eventi_miner_dynamite.text,"<i>""Ah, yeah ... did you bring the dynamite that our pastor asked you for?""</i>"
-Eventgive_dynamite.text,"<i>""Excellently. I'm going to take him to the pastor, and do not move from here""</i>"
+Eventi_miner_dynamite.button1,[you have the dinamite with you] Give him the dynamite
+Eventi_miner_dynamite.button2,I don`t have it.
+Eventi_miner_dynamite.text,"<i>""Ah, yeah... did you bring the dynamite that our pastor asked you for?""</i>"
+Eventgive_dynamite.text,"<i>""Excellent. I'm going to take this to the pastor... You... do not move from here.""</i>"
 Eventgive_dynamite.button1,Continue
 Eventno_dynamite.text,"<i>""You fool. You are useless if you can not do such a simple task. I will have to go there myself ... \n\n ... but before that...""</i>"
 Eventno_dynamite.button1,Continue
 Event_dynamite_quest.button1,Continue
 Event_carl_ask_about_dynamite.button1,Continue
-Tokenminer_body.text,In the corner you see a bending man.
+Tokenminer_body.text,In the corner a man is bending over.
 Tokenminer_body.button1,Talk to him
 Eventminer_body.text,You try to say something to a man but it seems that he can not hear you. You approach him and lightly pat him on the shoulder ...
 Eventminer_body.button1,Continue
-Eventminer_body_1.text,..with horror you see how the body falls to the ground. The man's head is smashed by a stone. You receive 1 facedown horror.
+Eventminer_body_1.text,..with horror you see the body fall to the ground. The man's head has been smashed by a stone.\n\n(Suffer 1 facedown horror)
 Eventminer_body_1.button1,Continue
-Eventminer_body_2.text,You can guess that the miner was bending something and had to catch a big stone that fell straight onto his head. Near his hand, you find {c:QItemcigarette} with matches.
+Eventminer_body_2.text,You can guess that the miner was bending down for something and a big stone fell straight onto his head. Near his hand, you find a {c:QItemcigarette} and a box of matches.
 Eventminer_body_2.button1,Continue
-Tokenminer_body_empty.text,Body of the miner
+Tokenminer_body_empty.text,Body of the miner.
 Tokenminer_body_empty.button1,Continue
-Eventchurch_reveal_from_doors.text,Through the keyhole, you see a large room, it seems familiar, like you've been here before. It looks like a newly built church. People sit on the benches, there is a very tall and well-built man at the altar, and on the altar ... you try to look but you can not get away from this distance. \n\n (Place: {c:Tilechurch} as indicated)
+Eventchurch_reveal_from_doors.text,Through the keyhole, you see a large room. It seems familiar, like you've been here before. It looks like a newly built church. People sit on the benches, there is a very tall and well-built man at the altar, and on the altar... You try to look but you can not see from this distance. \n\n (Place: {c:Tilechurch} as indicated)
 Eventchurch_reveal_from_doors.button1,Open the door
-Tokenchurch_crowd.text,..the people are listening to the sermon carefully
+Tokenchurch_crowd.text,..the people are listening to the sermon carefully.
 Tokenchurch_crowd.button1,Continue
-Tokenchurch_crowd_1.text,..the people are listening to the sermon carefully
+Tokenchurch_crowd_1.text,..the people are listening to the sermon carefully.
 Tokenchurch_crowd_1.button1,Continue
 Eventchurch_reveal_from_doors.button2,Wait
 Eventopen_door_to_church.text,The door opens quietly and you enter. You hear the pastor's speech about the end of the world.
 Eventopen_door_to_church.button1,Attack the pastor
-Eventchurch_reveal_from_secret.text,You go through a dark tunnel that climbs up. At the end, you come to a wooden hatch, open it slightly and through a crack you can see a large room, it seems familiar, as if you've been here before. It looks like a newly built church. People sit on the benches, there is a very tall and well-built man at the altar, and on the altar you try to look ... but you only see your legs. They look like the legs of a little boy ... it looks like these people are dangerous \n\n (Place: {c:Tilechurch} as indicated)
+Eventchurch_reveal_from_secret.text,You go through a dark tunnel that climbs up. At the end, you come to a wooden hatch, opening it slightly you look through the crack and can see a large room, it seems familiar, as if you've been here before. It looks like a newly built church. People sit on the benches, there is a very tall and well-built man at the altar, and on the altar you try to look... You only see legs. They look like the legs of a little boy... It looks like these people are dangerous. \n\n (Place: {c:Tilechurch} as indicated and you receive 1 {clue})
 Eventchurch_reveal_from_secret.button1,Continue
-Eventset_dynamite.text,That should surprise them ... \n\n You set the sun, throw it through the crack into the capillary and escape through the tunnel.
+Eventset_dynamite.text,That should surprise them... \n\n You set the fuse, throw it through the crack into the capillary and escape through the tunnel.
 Eventset_dynamite.button1,Continue
-Tokenevan_body.text,The boy's body. He has a burned head.
+Tokenevan_body.text,The boy's body. His head is burnt.
 Tokenevan_body.button1,({action}) Investigate
-Eventchurch_explode.text,Explode!! \n\n All investigators on tile {c:Tilechurch} suffers damage from dynamite.
+Eventchurch_explode.text,Explode!! \n\n All investigators on tile {c:Tilechurch} suffer 2 damage from the dynamite.
 Eventchurch_explode.button1,Continue
 Eventdynamite_from_body.text,You find something next to the body.
 Eventdynamite_from_body.button1,Continue
 Eventdynamite_question.text,Set up the dynamite?
-Eventdynamite_question.button1,({action}) Yes (i have dynamite with me)
+Eventdynamite_question.button1,[I have dynamite with me] ({action}) Yes
 Eventdynamite_question.button2,No, go back
-Tokenopen_secret_to_church.button2,Fail
-Eventnothing.text,Nothing interesting here
+Tokenopen_secret_to_church.button2,Failure
+Eventnothing.text,Nothing interesting here.
 Eventnothing.button1,Continue
-Eventgo_back_from_church.text,You go back through tunel
+Eventgo_back_from_church.text,You go back through the tunnel.
 Eventgo_back_from_church.button1,Continue
-UI1.uitext,It is October 1, 1920. Your friend invites you to a meeting at a nearby Baptist church. Over the phone, she said it was important, you sensed anxiety in her voice. You guess it's about the disappearance of her son John, the newspapers wrote about it. Apparently he has not found himself yet ...
+UI1.uitext,It is October 1, 1920.\n\nYour friend invites you to a meeting at a nearby Baptist church. Over the phone, she said it was important. In her voice, you sensed anxiety. Propably it's about the disappearance of her son, John. Not that long ago, the newspapers wrote about it. Apparently, he has not been found yet...\n\nAfter a short journey from your office, you arrive in the nearby mountain. You have heard that in the past copper was mined in the area. A friend wanted to meet you in the nearby small wooden church at the base of the rocks.\n\nThe church has its glory years behind it. Several years ago a part of it burned down in a fire. It was rebuilt and, although it can be seen that care was taken to reconstruct the small details in the form of simple shapes with narrow high windows, it has not regained its former glory.\n\nVarious strange legends are circulating around the area. It is said to be haunted since the fire broke out during one of the sermons of a controversial pastor. Many locals died, but the pastor himself was never found; neither alive nor dead.
 UI0.button1,Continue
-Eventstart_event.text,You go to church. It is quite old and damaged, it looks as if a fire broke out in it. \n\n Placeć {c:Tilechurch} as indicated
+Eventstart_event.text,You enter the church. It is quite old and damaged. It looks as if a fire broke out in it years ago. \n\n (Place {c:Tilechurch} as indicated)
 Eventstart_event.button1,Continue
-Eventstart_event_1.text,Your friend is sitting in the bench. She looks very sad. She is praying.
+Eventstart_event_1.text,Your friend is sitting on the bench. She looks very sad. She is praying.
 Eventstart_event_1.button1,Continue
-Eventstart_event_2.text,There is a tablet on the counter.
+Eventstart_event_2.text,There is a counter with an inscription that you can't read from this distance.
 Eventstart_event_2.button1,Continue
-Eventstart_event_3.text,There are nice decorated doors at the back.
+Eventstart_event_3.text,At the back of the church, there is an old, nicely decorated wooden shelf with books.
 Eventstart_event_3.button1,Continue
 Tokenfuture_doors_to_corridor.text,Large, nicely decorated door.
 Tokenfuture_doors_to_corridor.button1,({action}) Open
 Tokenfuture_exit.text,Exit
-Tokenfuture_exit.button1,({action} Go to the crime scene
-Eventstart_event_4.text,Place the investigatorss at the entrance.
+Tokenfuture_exit.button1,({action} Go to the crime scene.
+Eventstart_event_4.text,Place your Investigators as indicated.
 Eventstart_event_4.button1,Continue
 Eventstart_event_5.text,You hear the door closing behind you.
 Eventstart_event_5.button1,Continue
@@ -361,56 +361,58 @@ Tokenfriend.text,Your friend. Julie Mayer.
 Tokenfriend.button1,({action}) Talk to her
 Tokeninfo_table.text,The inscription on the counter.
 Tokeninfo_table.button1,({action}) Investigate
-Eventinfo_table.text,In memory of the victims of the fire that broke out here on December 12, 1901. You gain ({clue})
+Eventinfo_table.text,In memory of the victims of the fire that broke out here on December 12, 1901.\n\n(You receive 1 {clue})
 Eventinfo_table.button1,Continue
-Eventgo_to_crime_scene.text,You leave the church and go to the place where the boy's body was found. It is nearby, in a nearby forest.
+Eventgo_to_crime_scene.text,You leave the church and go to the place where the boy's body was found. It is in a nearby forest.\n\n(Remove all tiles from board)
 Eventgo_to_crime_scene.button1,Continue
 Eventfuture_corridor_reveal.text,You see the old stairs leading down. They are covered with a red dirty carpet. At the end, the corridor is lined with bookshelves. \n\n (Place {c:Tilestairs_up} as indicated})
 Eventfuture_corridor_reveal.button1,Continue
-Eventfuture_books.text,"You see a lot of thick books, each one is signed ""Journal of Works. Copper Mine"". Dates are from 1800 to 1900. Journal missing from 1850-1855. In the middle are tables with names, dates and quantity of extracted ore. \n\n You gain ({clue})"
+Tokenfurue_book_shelf_interaction.button1,({action}) Investigate
+Tokenfurue_book_shelf_interaction.text,Bookshelf.
+Eventfuture_books.text,"You see a lot of thick books, each one is signed ""Journal of Works. Copper Mine"". Dates are from 1800 to 1900. Journals are missing from 1850-1855. In the middle are tables with names, dates and quantities of extracted ore. \n\n(You receive 1 {clue})"
 Eventfuture_books.button1,Continue
-Eventjulie_talk.text,I'm glad you came to help me. As you probably know, my son was missing a few days ago. The police are helpless, they have not found any clues. I learned that a boy's body was found in a nearby forest. Fortunately, it was not my son. The police do not connect these two things, but I'm beginning to have a very bad feeling. Please, go to this place. Along the way, read the report of the coroner, whose photo I took at the coroner. \n\n Good luck. \n\n (All investigators gain ({clue})
+Eventjulie_talk.text,I'm glad you came to help me. As you probably know, my son went missing a few days ago. The police are unable to help, they have not found any clues.\nI learned that a boy's body was found in a nearby forest. Fortunately, it was not my son. The police did not connect these two things, but I'm beginning to have a very bad feeling. Please, go to this place. Along the way, read the report from the coroner, whose photo I took at the coroner.\nGood luck...\n\n (All investigators receive 1 {clue})
 Eventjulie_talk.button1,Continue
 Eventjulie_talk_1.text,The woman gets up. She wipes her eyes with a handkerchief and goes out through the door.
 Eventjulie_talk_1.button1,Continue
 EventSTART_GAME.button1,Continue
 Eventui_open.button1,Continue
-UI2.button1,Przycisk1
-EventSTART_GAME.text,Investigators start without any hints.
-Eventend_game_03_alone.text,You leave the mine. Your friends have never found a place, although you've spent many months searching for them. You also failed to solve the mystery of the boy's disappearance. You did not forgive for the rest of your life that you left them there.
+UI2.button1,Continue
+EventSTART_GAME.text,Investigators start without any clues.
+Eventend_game_03_alone.text,You leave the mine, defeated. Your friends were never found, although you spent many months searching for them. You also failed to solve the mystery of the boy's disappearance. You will never forgive yourself for leaving them there.
 Eventpast_dynamite.button3,Cancel
 Eventopen_door_to_church.button2,Listen to the sermon
-Eventchurch_event_1.text,"... the world is coming. The final judgment is approaching - the pastor is clearly speaking with the confidence and aggression characteristic of the preacher. ""You can see the proof in front of you."" - people stretch their heads to see better, some people sigh loudly, one woman starts to cry .. ""Here is the child, the victim of the world and the demons must bear the sacrifice with us!"" - the pastor screams. ""Amen"" - the faithful answer the choir. """
+Eventchurch_event_1.text,"<i>""...end of the world is coming. The final judgment is approaching""</i> - the pastor is clearly speaking with the confidence and aggressive characteristic of a preacher. <i>""You can see the proof in front of you.""</i> - people stretch their heads to see better, some people sigh loudly, one woman starts to cry .. <i>""Here is the child, the victim of the world and the demons must bear the sacrifice with us!""</i> - the pastor screams. <i>""Ejmen""</i> - the faithful answer the choir. "
 Eventchurch_event_1.button1,Continue
 Tokenevan_alive_questionmark.button1,({action}) Investigate
-Tokenevan_alive.text,The boy lies unconscious
-Eventevan_alive_menu.text,"You state with horror that this boy looks the same as the one found by the police officers, with the difference that he is alive and has no head injuries. ""What is going on here?"" - you whisper quietly. \n\n You receive 1 facedown horror."
+Tokenevan_alive.text,The boy lies unconscious.
+Eventevan_alive_menu.text,"You stare in horror, this boy looks the same as the one found by the police officers, with one difference, he is alive and has no head injuries. ""What is going on here?"" - you whisper quietly. \n\n(Suffer 1 facedown horror)"
 Eventevan_alive_menu.button1,Continue
 Tokenevan_alive_questionmark.text,A child lying on a stone altar.
 Tokenevan_alive.button1,Continue
-Tokencarl.text,The pastor speaks ... He is tall and muscular, he is confident and horrible. It's better not to disturb him.
+Tokencarl.text,The pastor speaks ... He is tall and muscular, he is overly confident, something about him horrifies you. It's better not to disturb him.
 Tokencarl.button1,({action}) Attack
 Eventchurch_event_2.text,"<i>""... the world is broken to the bone! Rape, murder. Our Lord is coming! Amen!""</i> - the pastor screams. \n\n The whole situation is more and more disturbing to you, you are feverishly thinking about how to get out of it. Maybe you can somehow distract them ..."
 Eventchurch_event_2.button1,Continue
 Event_body_raport.button1,Continue
-Event_carl_event.text,A huge explosion knocked all those gathered in the chapel. It is not known if anyone survived ... After a while when the persistent squeak in your ears begins to decrease, you hear that something is moving in the rubble of benches and bodies.
-Event_body_raport.text,From the coroner's report it appears that the boy died due to burning of the occipital part of the time. The boy was dressed in an outfit that resembles those from begining of 1900. The boy's age is about 10 years, same like John. The identity of the dead boy has not been confirmed, no one reported missing another boy in this area
+Event_carl_event.text,A huge explosion blasts all those gathered in the chapel. It is not known if anyone has survived ... After a while when the ringing in your ears subsides, you hear something moving among the rubble of benches and bodies.
+Event_body_raport.text,From the coroner's report it appears that the boy died due to burning of the occipital part of the time. The boy was dressed in an outfit that resembles those from begining of 1900. The boy's age was about 10 years, the same as John. The identity of the dead boy has not been confirmed, no one reported a missing boy in this area.
 Event_carl_event.button1,Continue
-Tokendebris.text,Rumble from benches and bodies.
+Tokendebris.text,Rubble from benches and bodies.
 Tokendebris.button1,Continue
-Tokenderbis_1.text,Rumble from benches and bodies.
+Tokenderbis_1.text,Rubble from benches and bodies.
 Tokenderbis_1.button1,Continue
-Tokencarl_body.text,Pastor, it seems barely alive ...
+Tokencarl_body.text,Pastor, he seems barely alive ...
 Tokencarl_body.button1,({action}) Attack
-Event_evan_body.text,You realize with horror that this is the same boy you read in the coroner's report, he has the same clothes and the same injuries. Your mind can not understand it. You recive 2 facedown horror,
+Event_evan_body.text,You realize with horror that this is the same boy as the one you read about in the coroner's report, he has the same clothes and the same injuries. Your mind can not comprehend it.\n\n(Suffer 2 facedown horror)
 Event_evan_body.button1,Continue
-Event_carl_event_1.text,The pastor, although he has received huge damage, slowly gets up, and his body changes ... you hear the terrifying scream of turning into a monster. All prospectors in the tile {c:Tilechurch} recive 1 facedown horror.
+Event_carl_event_1.text,The pastor, although having received huge damage, slowly gets up, and his body changes ... you hear the terrifying scream of a monster.\n\n(All Investigators in the {c:Tilechurch} tile suffer 1 facedown horror)
 Event_carl_event_1.button1,Continue
-Spawn_carl_monster.text,you could stay in your times...
+Spawn_carl_monster.text,You could stay in your times...
 Spawn_carl_monster.button1,Continue
-Token_carl_monster.text,you could stay in your times...
+Token_carl_monster.text,...you could stay in your times.
 Token_carl_monster.button1,Continue
-Event_carl_monster_dead.text,The monster dies, or rather melts in the air. His torn clothes and the silver key remain on the ground. You recive {c:QItem_silver_key}
+Event_carl_monster_dead.text,The monster dies, or rather melts into the air. His torn clothing and a silver key remain on the ground.\n\n(You receive the {c:QItem_silver_key} Unique Item)
 Event_carl_monster_dead.button1,Continue
 Event_silver_key.text,Silver key
 Event_silver_key.button1,Continue
@@ -418,49 +420,141 @@ Event_dynamite_inventory.text,Dynamite, you can blow something up.
 Event_dynamite_inventory.button1,Continue
 Event_carl_run.text,You get a feeling that you need to leave this place as soon as possible.
 Event_carl_run.button1,Continue
-Event_carl_run_1.text,Carl suddenly materializes on the altar ...
+Event_carl_run_1.text,Carl suddenly materializes in front of the altar ...
 Event_carl_run_1.button1,Continue
-Event_carl_run_2.text,... takes the boy's body and runs towards the mine ...
+Event_carl_run_2.text,...he takes the boy's body and runs towards the mine...
 Event_carl_run_2.button1,Continue
 Event_lamp.button1,Continue
-Event_lamp.text,{c:QItemlamp}
-Eventchurch_event_3.text,"<i>""Today we will make a great sacrifice to propitiate our master. We must sacrifice what is most important to us, that is why each of you...""</i> the pastor says in a raised voice, looking around the church, suddenly stops the sentence when he sees you."
+Event_lamp.text,Take the {c:QItemlamp} Common Item
+Eventchurch_event_3.text,"<i>""Today, we will make a great sacrifice to propitiate our master. We must sacrifice what is most important to us, that is why each of you...""</i>, the pastor says in a raised voice, looking around the church, suddenly stops the sentence when he sees you."
 Eventchurch_event_3.button1,Continue
 Eventchurch_event_question.text,Who are you?
 Eventchurch_event_question.button1,Continue
 Event_church_event_with_dynamite.text,"<i>""He's one of ours, I told him to bring dynamite. Did you bring?""</i>"
-Event_church_event_with_dynamite.button1,Give the dynamite
+Event_church_event_with_dynamite.button1,[You have a dinamite] Give the dynamite
 Event_church_event_with_dynamite.button2,I don`t have
 Eventchurch_event_give_dynamite.text,"<i>""Great, then we can start our sacrifice.""</i> Pastor takes dynamite from you."
 Eventchurch_event_give_dynamite.button1,Continue
-Eventchurch_event_0.text,You enter the chapel. Certainly it is a chapel in which you met with the mother of missing John but it looks different. It is new, pre-made. There are no traces of a fire. But it is impossible, have you started to lose your senses? You slowly walk past people, trying not to pay attention.\n\n You revice 1 facedown horror
+Eventchurch_event_0.text,"You enter the chapel. Certainly it is the chapel in which you met with the mother of the missing missing boy John, however it looks different now. It is new, freshly made. There are no hints of a fire.\n<i>""But... it is impossible, have you started to lose your senses?""</i>, your thoughts crumble in your heads.\nYou slowly walk past people, trying not to pay attention.\n\n(Suffer 1 facedown horror)"
 Eventchurch_event_0.button1,Continue
-Token_carl_waiting_for_dynamite.text,Pastor is speaking..
-Event_dynamite_quest.text,"<i>""Ah .. from the church. Well.""</i> - the man seems confused. <i>""In that case, go quickly find this miner, whom the pastor sent for dynamite and bring it to us ...""</i> - after a moment of thought, he adds <i>""dynamite, not a miner"".</i> Then he returns where he came from."
+Token_carl_waiting_for_dynamite.text,The Pastor is speaking..
+Event_dynamite_quest.text,"<i>""Ah .. from the church. Well.""</i> - the man seems confused. <i>""In that case, go quickly find the miner, the one the pastor sent for dynamite and bring it to us ...""</i> - after a moment of thought, he adds <i>""the dynamite, not the miner"".</i> Then he returns from where he came."
 Event_carl_ask_about_dynamite.text,"<i>""I was recently admitted to the church""</i> - you quickly make up the answer."
-Token_carl_waiting_for_dynamite.button1,({action}) Give him dynamite
-Event_john_feel.text,"You look in the terrified eyes of the boy... <i>""i d-don`t k-k-know ... where's my mom?""</i>"
+Token_carl_waiting_for_dynamite.button1,[You have a dynamite] ({action}) Give him dynamite
+Event_john_feel.text,"You look in the terrified eyes of the boy. You ask him, how is he feeling.\n<i>""I d-don`t k-k-know... O-ok... Where's my mom?""</i>\n\nThe boy is thin and pale. You ask about his name.\n<i>""My name i-is J-john.""</i>"\n\nSo this is the missing boy who you have been looking for, John.\n\n(You receive 1 {clue})
 Event_john_feel.button1,Continue
-Event_john_how_get_here.text,"<i>""I was playing in the woods when I saw this man. He was tall, he was dragging something behind him, he left it at the entrance to the mine in the bushes. I was very scared but did not notice me. I went to the mine because I did not want him to find me ... I was shifting in such a hideout in the wall but there was a hole in it, I ran into it ... then I only remember this room. I've been here for a very long time ...""</i> - You see how the boy's eyes are tearful."
+Event_john_how_get_here.text,"You feel thrilled that you have found him. You ask how he has got here.\n<i>""I was playing in the woods when I saw this man. He was tall, he was dragging something behind him, he left it at the entrance to the mine in the bushes. I was very scared but he did not notice me. I went to the mine because I did not want him to find me... I was searching the wall and founda hole, I climbed into it ... then I only remember this room. I've been here for a very long time ...""</i> - tears glisten in the boy's eyes."
 Event_john_how_get_here.button1,Continue
 Event_attack_carl_human.text,You take a huge metal candle stand and with all your strength you strike the pastor in the head.
 Event_attack_carl_human.button1,Continue
 Event_spawn_minions.text,You notice with horror that the rest of the audience is also changing ...
 Event_spawn_minions.button1,Continue
 Spawnminion1.button1,Continue
-Spawnminion1.text,<i>Amen.. amen.. amenn..</i> \n\n Place: {c:Spawnminion1} as indicated
+Spawnminion1.text,"<i>""Amen.. amen.. amenn..""</i> \n\n (Place: {c:Spawnminion1} as indicated)"
 Spawnminion_2.button1,Continue
-Spawnminion_2.text,AAAAmmeeeen!
+Spawnminion_2.text,"<i>""AAAAmmeeeen!""</i>"
 Token_carl_waiting_for_dynamite.button2,({action}) Attack
 Token_spell_book.button1,({action}) Take
 Event_slivering.button1,Continue
-Event_Machete.text,Looking at the pile of rubble you found {c:QItemMachete}
-Token_spell_book.text,You see a book with strange symbols bound in leather.
-Event_slivering.text,You recive {c:QItemshriveling}
+Event_Machete.text,You are watching the stones carefully looking for a gap that would allow you to see what is on the other side. After a while, you see a rusty, metal object.\n\n(You receive {c:QItemMachete})
+Token_spell_book.text,You see a leather bound book with strange symbols.
+Event_slivering.text,You receive {c:QItemshriveling} spell.
 Event_Machete.button1,Continue
-Tokenend_of_tunel_1.text,There is no transition
+Tokenend_of_tunel_1.text,There is no was through.
 Tokenend_of_tunel_1.button1,Continue
-Spawncultist.text,The door is open. A moment ago someone knocked one out of you. The hooded figure enters the room
-EventEvent_watch_from_past.text,"You watch the watch, it looks exactly like the one you found earlier in front of the mine, but it is much older and destroyed. It has exactly the same engraving on the back with the inscription: ""for Evan 1881"""
+Tokenend_of_tunel.button2,Defeat
+Spawncultist.text,The door is open. A moment ago someone knocked you out. The hooded figure enters the room.
+EventEvent_watch_from_past.text,"You inspect the watch. It looks exactly like the one you found earlier in front of the mine, but it is much older and destroyed. It has exactly the same engraving on the back with the inscription: ""for Evan 1881""."
 EventEvent_watch_from_past.button1,Continue
 Tokendynamite_after_fail.button3,Cancel
+EventTokenPastDoors1.text,In the second, slightly larger room there is a door.
+EventTokenPastDoors1.button1,Continue
+Eventpast_shelf_in_shelter0.text,At the end of the room is a bunk bed.
+Eventpast_shelf_in_shelter0.button1,Continue
+EventToken_go_to_future.button1,Continue
+EventToken_go_to_future.text,Behind you is the passage from which you fell.
+EventToken_torture_bed.text,In the middle of the room, there is a bed with leather straps attached.
+EventToken_torture_bed.button1,Continue
+Token_church_doors_to_mine.text,Massive doors, they are weathered from age.
+Token_church_doors_to_mine.button1,({action}) Investigate
+Event_church_doors_to_mine_explore.text,The doors are wooden, solidly made, fastened with thick metal straps. The handle on the door is large and old-fashioned.\nYou press on the handle but the door is closed. You try to see something through the keyhole but there is only darkness, and the musty smell of decaying wood.\n\n(You receive 1 {clue})
+Event_church_doors_to_mine_explore.button1,Continue
+Token_church_doors_to_mine_static.text,Old, massive doors. They are closed shut.
+Token_church_doors_to_mine_static.button1,Continue
+Tokenfuture_books_doors_reveal.text,You decide to take a look once again. You have a feeling that something is wrong with them ...
+Tokenfuture_books_doors_reveal.button1,({action}) Investigate
+Eventfuture_books_doors_reveal_test.text,You pull out books at random, hoping you will find something interesting.\n\nLore test {lore}.
+Eventfuture_books_doors_reveal_test.button1,Continue
+Eventfuture_books_doors_reveal_test.button2,Continue
+Eventfuture_books_doors_reveal_test.button3,Cancel
+Eventfuture_books_doors_reveal_success.text,You try to pull out another book, pulling it down, you hear a quiet click and feel that the shelf has moved slightly. After a closer examination, you see runners on the floor that allow you to easily move the shelf to one side. You stare with astonishment at how the shelf moves to reveal a nicely decorated door.
+Eventfuture_books_doors_reveal_success.button1,Continue
+Tokenfurue_book_shelf_open.text,Shelf with several books.
+Tokenfurue_book_shelf_open.button1,Continue
+Eventfuture_books_doors_reveal_fail.text,After a short while, you find that there is nothing interesting here. Simply, tables and numbers.
+Eventfuture_books_doors_reveal_fail.button1,Continue
+Event_church_doors_to_mine_knife.text,Going back upstairs, you see something metal sticking out from under the rug.\n\n(You receive {c: QItem_church_doors_to_mine_knife} Common Item)
+Event_church_doors_to_mine_knife.button1,Continue
+Eventend_of_tunel_fail.text,You inspect the rubble, looking for a slit that would allow you to see what is on the other side. Carefully you pull out a loose stone, unfortunately it causes a small avalanche that cascades in your direction. At the last moment you jump back but one of the stones is falling straight for your head.\n\n(Suffer 2 facedown damage cards ({agility} prevents)
+Eventend_of_tunel_fail.button1,Continue
+Tokenpast_doors1_blocked.text,The door is of a solid build. You can not open it in any way.
+Tokenpast_doors1_blocked.button1,Continue
+Eventpast_doors1_blocked.text,The door is a solid construction.  you can not open it in any way.
+Eventpast_doors1_blocked.button1,Continue
+Eventpast_end_game_alone0_place_invest.text,After a few minutes the remaining Investigators concerned about their missing companion gather in the room where they last saw him.\n\n(Place the remaining Investigators on the board. Investigators regain control over their characters)
+Eventpast_end_game_alone0_place_invest.button1,Continue
+Tokenpast_end_game_alone0_place_invest.button1,Kontynuuj
+Eventtime_test.button2,Cancel
+Eventtime_test_watch_trigger.text,You are surprised to discover that by turning the watch base you influence the symbol layout on the manhole cover. You have no idea how it works, but you can try different combinations.
+Eventtime_test_watch_trigger.button1,({action}) Solve the Puzzle
+Eventtime_test_watch_trigger.button2,Cancel
+Eventtime_test_no_watch.button1,Continue
+Eventtime_test_no_watch.text,You find a manhole made of rusty metal under the garbage. It is covered with strange symbols. You have no idea what they mean. Maybe you have missed a clue.
+Eventgo_to_future_disapear.button1,Continue
+EventEndgame_all_one_missing.text,You are leaving the mine. Despite many months of investigation, you fail to explain the death of the boy found or find John. What's worse, the lost Investigator was never found. For the rest of your life, you all wonder what actually happened on that rainy day, when you started the investigation. Did this really happening at all?
+EventEndgame_all_one_missing.button1,Continue
+EventEND_GAME.text,The End.\n\nThis is one of several possible endings.
+EventEND_GAME.button1,Continue
+Event_wakeup_in_john_room.text,You wake up in a stinking room. You recall the voices of the people who took you away. You can guess they moved you here. Slowly you open your eyes and look around the room.\n\n(Place: {c: Tilepast_boy_room} as indicated. Place the Investigator who came through the passage on the board)
+Event_wakeup_in_john_room.button1,Continue
+Event_wakeup_in_john_room_john_spawn.text,In the other part of the room, you see a wooden bed on which lies a young boy, approximatly 10 years old.
+Event_wakeup_in_john_room_john_spawn.button1,Continue
+Event_wakeup_in_john_room_doors.text,A solid metal door leads into the room.
+Event_wakeup_in_john_room_doors.button1,Continue
+Tokenpast_end_game_alone_pickaxe.text,\nYou see a rusty pickaxe leaning against the wall. Rust and dirt make it barely visible in the dim light of the tunnel.
+Tokenpast_end_game_alone_pickaxe.button1,({action}) Take
+Eventpast_end_game_alone_pickaxe_take.text,You receive {c:QItemaxe} Common Item.
+Eventpast_end_game_alone_pickaxe_take.button1,Continue
+Tokenend_of_tunel_destroyable.text,With the help of a pickaxe, you can try to dig out the passage.
+Tokenend_of_tunel_destroyable.button1,({action}) Continue
+Tokenend_of_tunel_destroyable.button2,Defeated
+Eventend_of_tunel_destroyable_success.text,With a great effort you managed to make a small passage to the other side. Through the hole, you see a tunnel fading into the darkness.\n\n(Place {c: Tilepast_mine_tuner_right} as indicated)
+Eventend_of_tunel_destroyable_success.button1,Continue
+Event_watch_ready_to_drop.text,"You inspect the watch very carefully, the glossy metal is thoroughly polished. There is an engraving on the back with the inscription: ""for Evan 1881"". It's in pretty good condition for a 40 year old watch. Mounted inside the watch is a mobile bazel, which is covered with strange symbols.\n\nYou are suddenly struck with the answer, this is the only chance for rescue. You hope that your companions will not be disappointed.\n\n(You receive 1 {clue})"
+Event_watch_ready_to_drop.button1,({action}) Slide the watch under the door.
+Event_watch_ready_to_drop.button2,Cancel
+Event_go_past_with_old_watch.text,This time, you are not going to risk it and wait for your companions.
+Event_go_past_with_old_watch.button1,({action}) Come to the passage together.
+Event_go_past_with_old_watch.button2,Cancel
+Event_go_past_with_old_watch1.text,You fly through the darkness, feeling the cold wind on your face...
+Event_go_past_with_old_watch1.button1,Continue
+EventMythos_minior_trigger.text,The room suddenly gets cold and the walls vibrate slightly. The feeling passes across your back and you a strange aura around you. \n\n(All Investigaotrs suffer 1 facedown horror ({will} negates))
+EventMythos_minior_trigger.button1,Continue
+Event_drop_watch.text,You slide the watch carefully under the door.\n\nPlace the  {c: QItem_watch_ready_to_drop} item in the indicated space.
+Event_drop_watch.button1,Continue
+Eventend_of_tunel_destroyable_door_reveal.text,On the right, you can see a solid looking metal door.
+Eventend_of_tunel_destroyable_door_reveal.button1,Continue
+Token_time_respawn.text,You suppose, you have to use the watch to reopen the passage.
+Token_time_respawn.button1,Continue
+Eventend_of_tunel_destroyable_fail0.text,Despite your constant attempts, you fail to make a passage. The stones are large and stuck together.
+Eventend_of_tunel_destroyable_fail0.button1,Continue
+Eventend_of_tunel_destroyable_fail1.text,You hit the rock with all your strength. Unfortunately, the pickaxe  bounces from the big stone and recoils back, glancing the side of your head.\n\n(Suffer 1 facedown damage ({agility} negates))
+Eventend_of_tunel_destroyable_fail1.button1,Continue
+Eventend_of_tunel_destroyable_fail2.text,Frustrated with the last of your strength, you hit the stones blindly. The entire structure unexpectedly crashes down directly onto you.\n\n(Suffer 2 facedown damage ({agility} negates). Then flip one damage faceup as the pile of stones knocks you down to the ground)
+Eventend_of_tunel_destroyable_fail2.button1,Continue
+Eventfriendfound.text,You are relieved to discover that your missing companion has also been found.
+Eventfriendfound.button1,Continue
+Event_john_watch_help.text,"John looks at you with a puzzled expression and finally says:\n<i> ""there in front of the mine near this .. that.. c-boy I saw the watch .. the same as yours ... is it the same watch? </i> - the boy asks a bit embarrassed."
+Event_john_watch_help.button1,Continue
+Eventtorture_bed1.text,A bed with leather belts attached. It looks like someone has been tied up here recently, judging from the blood trail it was a few hours ago\n\n(You receive 1 {clue})
+Eventtorture_bed1.button1,Continue

--- a/Localization.Polish.txt
+++ b/Localization.Polish.txt
@@ -1,14 +1,14 @@
 .,Polish
 quest.name,Pieśń wybrzeża v 0.1
-quest.description,<i>Rozwiąż zagadkę zaginięcia Johna, syna twojej dobrej przyjaciółki i zbadaj tajemnice starego kościoła baptystów z przełomu wieków</i>\n\nScenariusz jest przeznaczony dla 2-5 osób, wymaga kafelków z pierwszej edycji Posiadłości Szaleństwa. W tym scenariuszu w większości przypadków zrezygnowano z opisu tego jak należy ustawiać znaczniki, jest to celowy zabieg zachęcający graczy do uważnego śledzenia zmian w aplikacji jak również element mechaniki. Jeśli jakiś znacznik zostanie zauważony po czasie należy go umieścić na planszy i traktować jako dopiero co odkryty.\n\n<b>Uwaga: jeśli w trakcie rozgrywki pojawi polecenie usunięcia wszystkich kafelek z planszy, Faza Badaczy zaczyna się od nowa.</b>\n\nScenariusz jest nastawiony na fabułę, posiada kilka zakończeń, które wpływają na długość rozgrywki.\n\nWszelkie uwagi można kierować pod adresem:\nhttps://github.com/zcaalock/SotC/issues\n\nScenariusz jest stworzony przy użyciu:\nhttps://github.com/NPBruce/valkyrie\n\n\n
-quest.authors,zcaalock\nchrismaliszewski
-Token01_boy_body.button1,{action} Zbadaj
+quest.description,<i>Rozwiąż zagadkę zaginięcia Johna, syna twojej dobrej przyjaciółki i zbadaj tajemnice starego kościoła baptystów z przełomu wieków.</i>\n\nScenariusz jest przeznaczony dla 2-5 osób, wymaga kafelków z pierwszej edycji Posiadłości Szaleństwa. W tym scenariuszu w większości przypadków zrezygnowano z opisu tego jak należy ustawiać znaczniki, jest to celowy zabieg zachęcający graczy do uważnego śledzenia zmian w aplikacji jak również element mechaniki. Jeśli jakiś znacznik zostanie zauważony po czasie należy go umieścić na planszy i traktować jako dopiero co odkryty.\n\n<b>Uwaga: jeśli w trakcie rozgrywki pojawi polecenie usunięcia wszystkich kafelek z planszy, Faza Badaczy zaczyna się od nowa.</b>\n\nScenariusz jest nastawiony na fabułę, posiada kilka zakończeń, które wpływają na długość rozgrywki.\n\nWszelkie uwagi można kierować pod adresem:\nhttps://github.com/zcaalock/SotC/issues\n\nScenariusz jest stworzony przy użyciu:\nhttps://github.com/NPBruce/valkyrie\n\n\n
+quest.authors,zcaalock
+Token01_boy_body.button1,({action}) Zbadaj
 Event02_show_body_boy.button1,Kontynuuj
 TokenInvestigators.text,Umieść Badaczy na planszy.
 Event04_investigators.button1,Kontynuuj
 Event01_show_cave_enter_tile.button1,Kontynuuj
 Event04_investigators.text,Umieść Badaczy na planszy.
-Event03_take_watch.text,Widzisz ładny grawerowany zegarek. Możesz go dokładnie zbadać używając menu inwentarza. \n\n (Otrzymujesz {clue})
+Event03_take_watch.text,Widzisz ładny grawerowany zegarek. Możesz go dokładnie zbadać używając menu inwentarza. \n\n (Otrzymujesz 1 {clue})
 Event03_take_watch.button1,Kontynuuj
 Tokencave_shelter_show.text,Korytarz ciągnie się dalej w kierunku wschodnim.
 Token01_boy_body.text,W tym miejscu odnaleziono zwłoki chłopca. Po obejrzeniu sceny, w oczy rzuca ci się coś błyszczącego w słońcu.
@@ -21,71 +21,71 @@ Event01_show_cave_enter_tile.text,Parkujesz samochód przed małym lasem niedale
 Eventshow_cave_enter_token.button1,Kontynuuj
 Event02_show_body_boy.text,Rozwieszona lina ogradza miejsce, gdzie znaleziono zwłoki chłopca. Może policjanci coś przeoczyli.
 Token01_cave_enter.button1,{action} Sprawdź, czy drzwi są otwarte.
-Token01_cave_enter.text,Wejście do starej kopalni. Drzwi są drewniane i bardzo masywne.
+Token01_cave_enter.text,Wejście do starej kopalni. Drzwi są drewniane i bardzo masywne. Wyglądają na otwarte.
 Eventshow_cave_tile.text,Wchodzisz do starej kopalni. Z tego co słyszałeś, pochodzi ona najprawdopodobniej z okresu wojny secesyjnej. Cuchnie tu stęchlizną, a powietrze zastało się przez lata.\n\nMożesz przesunąć się o jedno pole do środka.\n\n (Umieść: {c:Tile02_cave_01} na planszy)
 Eventshow_cave_tile.button1,Kontynuuj
 Eventshow_observe_cave.text,Tunel niknie w ciemności.
 Eventshow_observe_cave.button1,Kontynuuj
 Eventshow_mine_end.text,W tym miejscu tunel jest zasypany. Nie masz szans się dalej przedostać.
 Eventshow_mine_end.button1,Kontynuuj
-Tokenend_of_tunel.button1,{action} Przeszukaj
+Tokenend_of_tunel.button1,({action}) Przeszukaj
 Eventshow_shelter_token.text,Po prawej stronie widzisz drewniane drzwi.
 Tokenend_of_tunel.text,Widzisz stertę kamieni i gruzu po zawalemniu się tunelu.. Nie ma przejścia. Możesz spróbować przeszukać stertę gruzu. \n\nTest spostrzegawczości {observation}.
 Eventshow_shelter_token.button1,Kontynuuj
 Tokendoor_to_shelter.text,Drewniane drzwi są bardzo zniszczone i ledwo się trzymają w zawiasach. Sądząc po śladach na podłodze, ktoś niedawno tędy przechodził.
 Tokendoor_to_shelter.button1,({action})Wejdź
-Evententer_to_shelter.text,Wchodzisz do cuchnącego stęchlizną i ziemią pomieszczenia. Jest tu stare rozwalające się piętrowe łóżko.
+Evententer_to_shelter.text,Wchodzisz do cuchnącego stęchlizną i ziemią pomieszczenia.\n\nJest tu stare rozwalające się piętrowe łóżko.
 Evententer_to_shelter.button1,Kontynuuj
 Eventshow_lamp_token.text,Lampa naftowa wisi na haku.
 Eventshow_lamp_token.button1,Kontynuuj
 Tokencave_lamp.text,Lampa naftowa.
 Tokencave_lamp.button1,({action}) Zabierz
 Tokenshelter_bed.text,Stare cuchnące łóżko.
-Tokenshelter_bed.button1,{action} Zbadaj
-EventShelter_old_bed.text,Wygląda na to, że przed laty spali tu górnicy. Przyglądasz się drewnianej konstrukcji łóżka piętrowego i dostrzegasz setki drobnych kresek wyrytych na powierzchni. Są zgrupowane po 6 i jedna przekreśla resztę. \n\n (Otrzymujesz {clue})
+Tokenshelter_bed.button1,({action}) Zbadaj
+EventShelter_old_bed.text,Wygląda na to, że przed laty spali tu górnicy. Przyglądasz się drewnianej konstrukcji łóżka piętrowego i dostrzegasz setki drobnych kresek wyrytych na powierzchni. Są zgrupowane po 6 i jedna przekreśla resztę. \n\n (Otrzymujesz 1 {clue})
 EventShelter_old_bed.button1,Kontynuuj
-Eventshelter_foodprints.text,Na zakurzonej podłodze dostrzegasz podłóżne ślady.
+Eventshelter_foodprints.text,Na zakurzonej podłodze dostrzegasz podłużne ślady.
 Eventshelter_foodprints.button1,Kontynuuj
-Tokencave_foodprints.text,Ślady na podłodze.
+Tokencave_foodprints.text,Ślady na podłodze i coś jeszcze...
 Tokencave_foodprints.button1,{action} Zbadaj
-Eventcave_footprints.text,Na podłodze dostrzegasz ślady stóp i dużą smugę, która ciągnie się od drzwi do małego pomieszczenia na końcu pokoju. \n\n (Otrzymujesz {clue})
+Eventcave_footprints.text,Na podłodze dostrzegasz ślady stóp i dużą smugę, która ciągnie się od drzwi do małego pomieszczenia na końcu pokoju. \n\n (Otrzymujesz 1 {clue})
 Eventcave_footprints.button1,Kontynuuj
 Eventtime_m.text,W małym pomieszczeniu na końcu pokoju widzisz stos śmieci.
 Eventtime_m.button1,Kontynuuj
 Tokentime.text,Stos śmieci; ktoś w pośpiechu próbował coś tu zasypać.
-Tokentime.button1,{action} Zbadaj
-Eventtime_test.text,Pod śmieciami znajdujesz jakiś właz zrobiony ze zaśniedziałego metalu. Cały jest pokryty dziwnymi symbolami. Dokładnie takimi jakie znajdują się na zegarku. \n\n(Tylko Badacz z przedmiotem {c:QItem01_watch} może wejść w interakcję z zagadką)
+Tokentime.button1,({action}) Zbadaj
+Eventtime_test.text,Pod śmieciami znajdujesz jakiś właz zrobiony ze zaśniedziałego metalu. Cały jest pokryty dziwnymi symbolami. Dokładnie takimi jakie znajdują się na zegarku. \n\n(Tylko Badacz z Przedmiotem powszechnym  {c:QItem01_watch} może wejść w interakcję z zagadką)
 Eventtime_test.button1,[Posiadam zegarek] Kontynuuj
 Puzzle0.button1,Sprawdź
-Eventtime_open.text,Słyszysz serię kliknięć, całe pomieszczenie wydaje się lekko wibrować. Ze zdumieniem odkrywasz. że otworzyło się przejście.
+Eventtime_open.text,Słyszysz serię kliknięć, całe pomieszczenie wydaje się lekko wibrować. Ze zdumieniem odkrywasz, że otworzyło się przejście.
 Eventtime_open.button1,Kontynuuj
 Tokentime_enter.button1,Wejdź
-Eventgo_in_time.text,Zaczynasz się schylać aby wejść do środka ale zatrzymujesz się w pół kroku zastanawiając się czy czekać na towarzyszy.
-Eventgo_in_time.button1,{action} Idź sam
+Eventgo_in_time.text,Zaczynasz się schylać, aby wejść do środka, ale zatrzymujesz się w pół kroku zastanawiając się, czy czekać na towarzyszy.
+Eventgo_in_time.button1,({action}) Idź sam
 Eventtime_alone.text,Potykasz się i wpadasz z impetem do dziury. Czujesz na twarzy pęd zimnego powietrza...\n\n(Usuń wszystkie kafelki z planszy)\n\n(W tym momencie akcja dzieje się z perspektywy Badacza, który wszedł do tajnego przejścia. Pozostali Badacze nie mogą wykonywać żadnych akcji.)
 Eventtime_alone.button1,Kontynuuj
 Eventwait_for_friends.text,Wołasz swoich towarzyszy. Po chwili przychodzą, próbujesz ich przekonać, żeby weszli tam z tobą.
-Eventwait_for_friends.button1,{action} Wejdźcie razem
+Eventwait_for_friends.button1,({action}) Wejdźcie razem
 Tokentime_enter.text,Przejście jest nachylone i prowadzi pod ziemię. Czujesz zimny powiew wiatru i jakby zjonizowane powietrze.
 Eventgo_in_time.button2,Czekaj na resztę
 Eventall_go_in_time.text,Lecisz chwile przez ciemność, czując zimny wiatr na twarzy.. \n\n (Usuń wszystkie kafelki z planszy)
 Eventall_go_in_time.button1,Kontynuuj
 Eventwait_for_friends.button2,Nie wchodźcie
-Eventpast_start_event.text,...wpadasz z impetem do małego jasnego pomieszczenia na twarde płytki. Każdy Badacz, który teraz przeszedł przez przejście otrzymuje 2 zakryte karty Obrażeń ({agility} zapobiega).
+Eventpast_start_event.text,...wpadasz z impetem do małego jasnego pomieszczenia na twarde płytki.\n\n(Każdy Badacz, który teraz przeszedł przez przejście otrzymuje 2 zakryte karty Obrażeń ({agility} zapobiega))
 Eventpast_start_event.button1,Kontynuuj
-Eventpast_show_items_torture_room.text,Próbująć się podnieść obrzucasz spojrzeniem całe pomieszczenie. Jest to mały pokój wyłożony białymi płytkami, jest tu czysto i jasno.\n\n (Umieść: {c:Tilepast_shelter} na planszy)
+Eventpast_show_items_torture_room.text,Próbując się podnieść obrzucasz spojrzeniem całe pomieszczenie. Z jednej strony widzisz przejście, przez które przed momentem wpadłeś. Znalazłeś się w małym pokoju wyłożonymi białymi płytkami. Jest tu czysto i jasno. Ze zdziwieniem zauważasz stojące na środku łóżko ze skórzanymi pasami.\n\n (Umieść: {c:Tilepast_shelter} na planszy)
 Eventpast_show_items_torture_room.button1,Kontynuuj
 Tokengo_to_future.text,Przejście z którego wypadłeś.
 Tokengo_to_future.button1,Wejdź przez przejście
 Tokenpast_doors1.text,Drzwi. Ciekawe gdzie prowadzą.
 Tokenpast_doors1.button1,Zbadaj
-Tokentorture_bed.text,Łóżko z pasami
-Tokentorture_bed.button1,{action} Zbadaj
-Eventtorture_bed.text,Skórzane łózko jest umazane krwią, po bokach luźno zwisają pasy. Obok łóżka stoi jakieś urządzenie z kablami przyczepionymi do opaski na głowę.\n\n (Otrzymujesz {clue})
+Tokentorture_bed.text,Łóżko z ciężkimi skórzanymi pasami.
+Tokentorture_bed.button1,({action}) Zbadaj
+Eventtorture_bed.text,Przyglądając się łóżku dostrzegasz ślady krwi. Dodatkowo okazuje się, że jest nieznacznie przypalone po jednej stronie. Obok łóżka stoi jakieś urządzenie z kablami przyczepionymi do opaski na głowę.\n\n (Otrzymujesz 1 {clue})
 Eventtorture_bed.button1,Kontynuuj
 Eventgo_to_future_.text,Ogarnia cię przeczucie, że nie powinieneś tam wchodzić bez swoich przyjaciół.
-Eventgo_to_future_.button1,{action} Idź sam
-Eventgo_to_future_.button2,{action} Wejdźcie razem
+Eventgo_to_future_.button1,({action}) Idź sam
+Eventgo_to_future_.button2,({action}) Wejdźcie razem
 Eventgo_to_future_alone.text,Wchodzisz do przejścia sam i znowu mkniesz szybko przez pustkę.
 Eventgo_to_future_alone.button1,Kontynuuj
 Eventgo_to_future_all.text,Wskakujesz do przejścia i znowu mkniesz przez pustkę..
@@ -93,33 +93,33 @@ Eventgo_to_future_all.button1,Kontynuuj
 Eventback_in_future.text,Wypadasz na stertę śmieci. Po chwili udaje ci się wygrzebać i stanąć na nogach. Rozglądasz się i widzisz to samo pomieszczenie w kopalni, z którego na początku przyszedłeś. Patrzysz za siebie i widzisz, że przejście zniknęło. Dotykasz desperacko każdego kawałka podłogi i ściany, wołasz swoich przyjaciół ale nie ma żadnego odzewu. Po kilkunastu minutach zrezygnowany wychodzisz na zewnątrz szukać pomocy.
 Eventback_in_future.button1,Kontynuuj
 Tokenwatch_from_past.text,Na podłodze widzisz jakiś zaśniedziały, wyglądający na stary kawałek okrągłego metalu.
-Tokenwatch_from_past.button1,{action} Zbadaj
-Eventwatch_from_past.text,"To stary zegarek kieszonkowy. Wygląda identycznie jak ten, który znaleźliście w miejscu gdzie było ciało chłopca. Tylko, że ten zegarek jest dużo starszy, cały jest zardzewiały i ma zbitą szybkę... Zaraz, zaraz, przecież to ten sam zegarek, ma z tyłu grawer z napisem ""dla Evana 1881"". To niemożliwe..."
+Tokenwatch_from_past.button1,({action}) Zbadaj
+Eventwatch_from_past.text,"To stary zegarek kieszonkowy. Wygląda identycznie jak ten, który znaleźliście w miejscu gdzie było ciało chłopca. Tylko, że ten zegarek jest dużo starszy! Jest cały zardzewiały i ma zbitą szybkę... Zaraz, zaraz, przecież to ten sam zegarek! Ma z tyłu grawer z napisem ""dla Evana 1881"". To niemożliwe...?"
 Eventwatch_from_past.button1,Kontynuuj
-Tokenmessage_from_past.text,Stare łóżko.
-Tokenmessage_from_past.button1,{action} Zbadaj
-Eventmessage_from_past.text,Widzisz łóżko pokryte kreskami tak jak wcześniej. Jednak w tym momencie dostrzegasz coś jeszcze. Po bliższym przyjrzeniu się drewnianej konstrukcji widzisz napis wyryty na jednej z desek. Jest stary, ale udaje ci się go odczytać.
+Tokenmessage_from_past.text,Stare łóżko. Wygląda nieco inaczej niż wcześniej.
+Tokenmessage_from_past.button1,({action}) Zbadaj
+Eventmessage_from_past.text,Pomimo, że łóżko nadal pokryte jest kreskami tak jak wcześniej, po bliższym przyjrzeniu się drewnianej konstrukcji, stwierdzasz że obok niech pojawił się napis niepokojący napis wyryty na jednej z desek. Choć wygląda na stary, może uda się go odczytać.
 Eventmessage_from_past.button1,Kontynuuj
-Eventmessage_from_past_1.text,"Z trudnością odczytujesz wiadomość: ""K****kol**ek to przec***asz, **atuj mni*"". Nie masz pojęcia co to ma znaczyć.\n\n (Otrzymujesz {clue})"
+Eventmessage_from_past_1.text,"Z trudnością odczytujesz wiadomość: ""Kie**kol**ek to przec***asz, **atuj mn*e"".\n\n (Otrzymujesz 2 karty Przerażenia i otrzymujesz 1 {clue})"
 Eventmessage_from_past_1.button1,Kontynuuj
 Tokenend_game_alone.button1,{action} Wyjdź
 Eventend_game_03_alone.button1,Kontynuuj
 Eventgo_to_future_.button3,Czekaj na resztę
-Event_back_in_future_all.text,Niezgrabnie wychodzisz do cuchnącego pomieszczenia starej kopalni. Dookoła są rozrzucone śmieci
+Event_back_in_future_all.text,Niezgrabnie wychodzisz do cuchnącego pomieszczenia starej kopalni. Dookoła są rozrzucone śmieci.
 Event_back_in_future_all.button1,Kontynuuj
 Tokenend_game_all.text,Wyjście na zewnątrz (koniec gry)
-Tokenend_game_all.button1,{action} Kontynuuj
-Eventend_game_all.text,Wychodzicie z kopalni. Mimo wielomiesięcznego śledztwa nie udaje wam się wyjaśnić śmierci znalezionego chłopca ani odnaleźć Johna. Do końca życia każdy z was się zastanawia co właściwie się stało tego deszczowego dnia kiedy zaczęliście śledztwo. Czy to w ogóle się wydarzyło naprawdę?
+Tokenend_game_all.button1,({action}) Kontynuuj
+Eventend_game_all.text,Wychodzicie z kopalni. Mimo wielomiesięcznego śledztwa nie udaje wam się wyjaśnić śmierci znalezionego chłopca ani odnaleźć Johna. \n\nDo końca życia każdy z was się zastanawia co właściwie się stało tego deszczowego dnia kiedy zaczęliście śledztwo.\n\nCzy to w ogóle się wydarzyło naprawdę?
 Eventend_game_all.button1,Kontynuuj
 Tokenend_game_alone.text,Przejście prowadzi na zewnątrz. (Koniec gry)
 Tokenpast_shelf_in_shelter.text,Widzisz łóżko piętrowe. Świeża farba i brudna cuchnąca pościel sugerują, że od czasu do czasu ktoś tu śpi.
-Tokenpast_shelf_in_shelter.button1,{action} Przeszukaj
+Tokenpast_shelf_in_shelter.button1,({action}) Przeszukaj
 Eventpast_shelf_in_shelter.button1,Kontynuuj
-Eventpast_shelf_in_shelter_all.text,Czujesz ogromny ból w okolicach potylicy, a zaraz potem robi ci się ciemno przed oczami... \n\n (Otrzymujesz stan ogłuszony i tracisz tracisz tę turę)
-Eventpast_end_game_alone.text,"Czujesz ogromny ból w okolicach potylicy, a zaraz potem robi ci się ciemno przed oczami...\nBudzisz się po jakimś czasie w tym samym miejscu. Drzwi wejściowe są zabarykadowane i nie jesteś w stanie w żaden sposób ich otworzyć. Przeczesujesz całe pomieszczenie w poszukiwaniu jakiegoś wyjścia. Niestety wygląda na to, że tu utknąłeś.\nW pomieszczeniu jest zmagazynowane dużo jedzenia i wody. Niestety po kilku godzinach lampa naftowa się wypada i zostajesz w całkowitej ciemności.\nTracisz kompletnie poczucie czasu. Próbujesz liczyć dni, które tu spędziłeś ryjąc w drewnie łóżka kreski. Po bliżej nieokreślonym czasie, może po kilku tygodniach, a może miesiącach, postanawiasz wyryć napis: ""Kiedykolwiek to przeczytasz, uratuj mnie"". \nZasypiasz wyczerpany.\n\n(Jeśli jakieś żetony pozostały na {c:Tilepast_shelter}, usuń je)"
+Eventpast_shelf_in_shelter_all.text,Czujesz ogromny ból w tyle głowy, a zaraz potem robi ci się ciemno przed oczami... \n\n (Wszyscy Badacze otrzymujesz stan Ogłuszony i tracą resztę akcji w tej turze)
+Eventpast_end_game_alone.text,"Czujesz ogromny ból w tyle głowy, a zaraz potem robi ci się ciemno przed oczami...\nBudzisz się po jakimś czasie w tym samym miejscu. Drzwi wejściowe są zabarykadowane i nie jesteś w stanie w żaden sposób ich otworzyć. Przeczesujesz całe pomieszczenie w poszukiwaniu jakiegoś wyjścia. Niestety wygląda na to, że tu utknąłeś.\nW pomieszczeniu jest zmagazynowane dużo jedzenia i wody. Niestety po kilku godzinach lampa naftowa się wypada i zostajesz w całkowitej ciemności.\nTracisz kompletnie poczucie czasu. Próbujesz liczyć dni, które tu spędziłeś ryjąc w drewnie łóżka kreski. Po bliżej nieokreślonym czasie, może po kilku tygodniach, a może miesiącach, postanawiasz wyryć napis: ""Kiedykolwiek to przeczytasz, uratuj mnie"". \nZasypiasz wyczerpany.\n\n(Jeśli jakieś żetony pozostały na {c:Tilepast_shelter}, usuń je)"
 Eventpast_end_game_alone.button1,Kontynuuj 
 Eventgo_to_future_disapear.text,Ze zdziwieniem stwierdziłeś, że przejście zniknęło. Przed sobą widzisz gołą ścianę wyłożoną płytkami.
-Eventpast_end_game_alone0.text,Chwilę po tym jak Badacz sam wskoczył od przejścia zamyka się ono ukazując ścianę pokrytą brudnymi zniszczonymi płytkami. \n\n(Umieść: {c:Tile01_Cave_entrance}, {c:Tile02_cave_01}, {c:Tile03_cave_shelter} na planszy)
+Eventpast_end_game_alone0.text,Chwilę po tym jak Badacz sam wskoczył do dziwnego przejścia, zamyka się ono pozostawiając po sobie ścianę pokrytą brudnymi zniszczonymi płytkami. \n\n(Umieść: {c:Tile01_Cave_entrance}, {c:Tile02_cave_01}, {c:Tile03_cave_shelter} na planszy)
 Eventpast_end_game_alone0.button1,Kontynuuj
 Eventthe_end.text,Koniec.
 Eventthe_end.button1,Kontynuuj
@@ -130,11 +130,11 @@ Eventpast_mine_show.text,Za przeciwnikiem widać słabo oświetlone pomieszczeni
 Eventpast_mine_show.button1,Kontynuuj
 Tokenpast_mine_show_left.text,Korytarz prowadzi dalej w tę stronę.
 Tokenpast_mine_show_left.button1,Odkryj
-Eventpast_mine_show2.text,Tunel prowadzi prosto a potem zakręca w lewo. Biorąc pod uwagę zimne powietrze, które płynie z tego kierunku, tam musi być wyjście. \n\n(Umieść: {c:Tile02_cave_01} na planszy)
+Eventpast_mine_show2.text,Tunel prowadzi prosto, a potem zakręca w lewo. Biorąc pod uwagę zimne powietrze, które płynie z tego kierunku, tam musi być wyjście. \n\n(Umieść: {c:Tile02_cave_01} na planszy)
 Eventpast_mine_show2.button1,Kontynuuj
 Tokenpast_mine_exit.text,Drzwi na zewnątrz. Są zamknięte, nie uda ci się ich otworzyć.
 Tokenpast_mine_exit.button1,({action}) Zbadaj
-Eventpast_show_outside.text,Przez szparę w drzwiach widzisz jakąś polanę otoczoną gęstym lasem.\n\n(Otrzymujesz {clue})\n\n (Umieść: {c:Tile01_Cave_entrance} na planszy)
+Eventpast_show_outside.text,Przez szparę w drzwiach widzisz jakąś polanę otoczoną gęstym lasem.\n\n(Otrzymujesz 1 {clue})\n\n (Umieść: {c:Tile01_Cave_entrance} na planszy)
 Eventpast_show_outside.button1,Kontynuuj
 Tokenpast_mine_show_right.text,Tunel w tym miejscu zaczyna schodzić w dół.
 Tokenpast_mine_show_right.button1,Odkryj
@@ -144,127 +144,127 @@ Eventpast_mine_tunel_right_items_show.text,Na ziemi widzisz ciągnące się wsz�
 Eventpast_mine_tunel_right_items_show.button1,Kontynuuj
 Tokenpast_mine_right_tunnel_dynamite.text,Plątanina dziwnych cienkich lin.
 Tokenpast_mine_right_tunnel_dynamite.button1,({action}) Zbadaj
-Eventpast_dynamite.text,Ku swojemu zdziwieniu odkrywasz, że to są laski dynamitu przyczepione do belek trzymających strop.  \n\n (Otrzymujesz {clue})\n\n (Możesz wziąć 1 laskę dynamitu ze sobą. Test spostrzegawczości {observation}.)
+Eventpast_dynamite.text,Ku swojemu zdziwieniu odkrywasz, że to są laski dynamitu przyczepione do belek trzymających strop. \n\n (Otrzymujesz 1 {clue})\n\n (Możesz wziąć 1 laskę dynamitu ze sobą. Test spostrzegawczości {observation}.)
 Eventpast_dynamite.button1,Weź
 Tokenpast_tunel_right_end.button1,Odkryj
 Tokenpast_tunel_door.text,Ciężkie metalowe drzwi. Żeby je otworzyć potrzebny jest srebrny klucz.
 Tokenpast_tunel_right_end.text,Tunel biegnie dalej w tym kierunku.
-Tokenpast_tunel_door.button1,{action} Otwórz
-Eventpast_tunel_door_open.text,Przekręcasz klucz w zamku, idealnie pasuje. Otwierasz drzwi z wielkim zgrzytem..
+Tokenpast_tunel_door.button1,({action}) Otwórz
+Eventpast_tunel_door_open.text,Przekręcasz klucz w zamku. Pasuje idealnie. Otwierasz drzwi z wielkim zgrzytem...
 Eventpast_tunel_door_open.button1,Kontynuuj
 Eventpast_boy_room_reveal.text,...Twoim oczom ukazuje się ciemne pomieszczenie. \n\n (Umieść: {c:Tilepast_boy_room} na planszy)
 Eventpast_boy_room_reveal.button1,Kontynuuj
 Eventpast_boy_found.text,Na łóżku leży jakaś postać. Po dokładnym przyjrzeniu się stwierdzasz, że to mały John. Widać, że jest w kiepskim stanie ale przynajmniej żyje.
 Eventpast_boy_found.button1,Kontynuuj
-TokenJohn.text,Widzisz chłopca w wieku około 10 lat.
-TokenJohn.button1,{action} Rozmawiaj?
-Eventtake_john.text,Bierzesz Johna na ręce. Od tej chwili do momentu, aż zostawisz Johna możesz wykonać tylko jedną akcję na turę.
+TokenJohn.text,Widzisz chłopca w wieku około 10 lat. Gdy podchodzisz, powoli otwiera oczy.
+TokenJohn.button1,({action}) Rozmawiaj?
+Eventtake_john.text,Bierzesz Johna na ręce.\n\n(Od tej chwili do momentu aż uratujesz Johna, możesz wykonać tylko jedną akcję na turę)
 Eventtake_john.button1,Kontynuuj
-Eventend_game_alone_with_john.text,Wychodzisz z kopalni. Twoi przyjaciele nigdy się nie znaleźli chociaż poświęciłeś na ich szukanie wiele miesięcy. Nie udało ci się także rozwiązać tajemnicy morderstwa chłopca znalezionego przed kopalnią. Cały czas nie daje ci spokoju to, że wydaje ci się, że to był ten sam chłopiec którego widziałeś tam wśród tej okropnej sekty. Miał na sobie te same ubrania. Ale jak to możliwe, jak on przecież nie żył... Do końca życia sobie nie wybaczysz tego, że zostawiłeś tam swoich przyjaciół. Ale czy to naprawdę się wydarzyło? Jedyne co cię pociesza to to, że John jest bezpieczny. Ostatnio coraz rzadziej cię odwiedza sanatorium... patrzysz zamyślony przez zakratowane okno jak nad Arkham zachodzi słońce.
+Eventend_game_alone_with_john.text,Wychodzisz z kopalni. Twoi przyjaciele nigdy się nie odnaleźli chociaż poświęciłeś na ich szukanie wiele miesięcy. Do końca życia nie wybaczysz sobie tego, że zostawiłeś tam swoich przyjaciół. Bo jak mogłeś to zrobić...\nNie udało ci się także rozwiązać tajemnicy morderstwa chłopca znalezionego przed kopalnią. Cały czas nie możesz oprzeć się temu niepokojącemu wrażeniu, że to był ten sam chłopiec, którego widziałeś na ołtarzu wśród przedstawicieli tej okropnej sekty. Miał na sobie te same ubrania. Ale jak to możliwe? On przecież nie żył, prawda...?\n Jedyne co cię pociesza to to, że John jest bezpieczny. Niestety, ostatnio odwiedza cię coraz rzadziej, podczas gdy ty patrzysz się zamyślony jak nad Arkham zachodzi słońce siedząc samotnie w białym pokoju z  zakratowanymi oknami.
 Eventend_game_question_john.text,Czy John jest z tobą?
 Eventend_game_question_john.button2,Nie
 Eventend_game_alone_with_john.button1,Kontynuuj
 Eventend_game_all_without_john.button1,Kontynuuj
-Eventend_game_alone_without_john.text,Wychodzisz z kopalni. Twoi przyjaciele nigdy się nie znaleźli chociaż poświęciłeś na ich szukanie wiele miesięcy. Nie udało ci się także rozwiązać tajemnicy morderstwa chłopca. Do końca życia sobie nie wybaczyłeś tego, że ich tam zostawiłeś. Najbardziej Ci żal Johna, często o nim myślisz leżąc i patrząc przez zakratowane okno sanatorium w Arkham.
+Eventend_game_alone_without_john.text,Wychodzisz z kopalni. Twoi przyjaciele nigdy się nie znaleźli chociaż poświęciłeś na ich szukanie wiele miesięcy. Nie udało ci się także rozwiązać tajemnicy morderstwa chłopca znalezionego przed kopalnią. Do końca życia nie wybaczyłeś sobie tego, że zostawiłeś ich tam wszystkich...\nJednak największy żal przepełnia cię w momentach, gdy myślisz o Johnie, małym chłopcy, któremu nie udało ci się pomóc w powrocie do jego rozgoryczonej matki, która ostatecznie popełniła samobójstwo... Często myślisz o nim i o Jane leżąc na swoim pasiastym łóżku i patrząc przez okno na mroczne bezgwiezdne niebo przez kraty sanatorium w Arkham.
 Eventend_game_alone_without_john.button1,Kontynuuj
-Eventend_game_all_with_john.text,Wychodzicie z kopalni. Niestety nie udało wam się się rozwiązać tajemnicy morderstwa chłopca znalezionego przed kopalnią. Cały czas nie daje wam spokoju to, że wydaje się wam, że to był ten sam chłopiec którego widzieliście tam wśród tej okropnej sekty. Miał na sobie te same ubrania. Ale jak to możliwe, jak on przecież nie żył... Ale czy to naprawdę się wydarzyło? Na szczęście John jest bezpieczny.
+Eventend_game_all_with_john.text,Wychodzicie z kopalni. Niestety nie udało ci się rozwiązać tajemnicy morderstwa chłopca znalezionego przed kopalnią. Cały czas nie możesz oprzeć się temu niepokojącemu wrażeniu, że to był ten sam chłopiec, którego widziałeś na ołtarzu wśród przedstawicieli tej okropnej sekty. Miał na sobie te same ubrania. Ale jak to możliwe? On przecież nie żył, prawda...?\nNa szczęście John jest bezpieczny, chociaż przeszedł traumę po wydarzeniach z kopalni i już nigdy nie był tym samym chłopcem jak wcześniej.
 Eventend_game_all_with_john.button1,Kontynuuj
 Event_watch.text,"Zegarek jest zrobiony bardzo starannie. Błyszczący metal jest dokładnie wypolerowany. Z tyłu znajduje się grawer z napisem: ""dla Evana 1881"". Całkiem nieźle się trzyma jak na 40 letni zegarek! Na kopercie zegarka jest zamontowany ruchomy bezel, który pokryty jest dziwnymi symbolami."
 Event_watch.button1,Kontynuuj
-Eventshow_watch_from_past.text,Rozglądając się po pomieszczeniu dostrzegasz coś mieniącego się na podłodze.
+Eventshow_watch_from_past.text,Rozglądając się po pomieszczeniu, dostrzegasz coś mieniącego się na podłodze.
 Eventshow_watch_from_past.button1,Kontynuuj
 Eventpast_dynamite.button2,Porażka
-Eventtake_dynamite.text,Udaje ci się wyplątać jedną laskę dynamitu.
+Eventtake_dynamite.text,Udaje ci się wyplątać jedną laskę dynamitu.\n(Otrzymujesz {c:QItemshot_gun} Przedmiot powszechny)
 Eventtake_dynamite.button1,Kontynuuj
 Eventtake_dynamite_fail1.text,Nie udało ci się wyplątać dynamitu z tego węzła gordyjskiego.
 Eventtake_dynamite_fail1.button1,Kontynuuj
-Tokendynamite_after_fail.text,Widzisz splątane laski dynamitu. Możesz spróbować wyjąć dynamit jeszcze raz.  \n\n\ Test zwinności {agility}.
+Tokendynamite_after_fail.text,Widzisz splątane laski dynamitu. Możesz spróbować wyjąć dynamit jeszcze raz. \n\n\ Test zwinności {agility}.
 Tokendynamite_after_fail.button1,({action}) Weź
 Tokendynamite_after_fail.button2,Porażka
-Eventtake_dynamite_2_fail.text,Bezskutecznie próbujesz wydobyć laskę dynamitu z plątaniny sznurków nasączonych naftą. Całkiem nieopatrznie wpadł ci głupi pomysł do głowy aby rozjaśnić to miejsce lampą oliwną. Niestety wypadła ci z rąk i płomień rozlał się na połowę tunelu...
+Eventtake_dynamite_2_fail.text,Bezskutecznie próbujesz wydobyć laskę dynamitu z plątaniny sznurków nasączonych naftą. Wpadasz na pomysł, aby rozjaśnić to miejsce lampą oliwną. Niestety wypadła ci z rąk i płomień rozlał się na połowę tunelu. Na twoje nieszczęście, rozprzestrzenił się tak szybko, ze nie jesteś w stanie go ugasić...
 Eventtake_dynamite_2_fail.button1,Kontynuuj
-Eventfire_event_start.text,Płomienie zaczęły się bardzo szybko rozprzestrzeniać po zakurzonej podłodze i pajęczynach na ścianach. Instynktownie rozumiesz, że nie masz wiele czasu na ucieczkę..
+Eventfire_event_start.text,Płomienie zaczęły rozprzestrzeniać się bardzo szybko po zakurzonej podłodze i pajęczynach na ścianach.\nInstynktownie rozumiesz, że nie masz wiele czasu na ucieczkę!
 Eventfire_event_start.button1,Kontynuuj
-Eventfire_endin_begin.text,Ogień się szybko rozprzestrzenia, zaraz dojdzie do dynamitu. Musicie uciekać.. Każdy Badacz otrzymuje 1 kartę Przerażenia.
+Eventfire_endin_begin.text,Ogień się szybko rozprzestrzenia, zaraz dojdzie do dynamitu. Musicie uciekać!\n\n(Każdy Badacz otrzymuje 1 kartę Przerażenia)
 Eventfire_endin_begin.button1,Kontynuuj
-Eventfire_ending_mieddle.text,Z głębi tunelu słyszysz jakieś krzyki. Zza zamkniętych drzwi dochodzi jakieś wołanie. Wydaje ci się, że to głos dziecka ale próbujesz sobie tego nie uświadamiać. Wszystko zaczyna palić się jak pochodnia. Ogień doszedł do lontu i za chwile wszystko wybuchnie. Macie ostatnią szansę na ucieczkę.
+Eventfire_ending_mieddle.text,Z głębi tunelu słyszysz jakieś krzyki. Zza zamkniętych drzwi dochodzi jakieś wołanie. Wydaje ci się, że to głos dziecka, ale wolałbyś, aby nie była to prawda. \nWszystko zaczyna palić się jak pochodnia. Ogień doszedł do lontu i za chwilę wszystko wybuchnie.\n\n(Macie ostatnią szansę na ucieczkę)
 Eventfire_ending_mieddle.button1,Kontynuuj
-Eventexplode.text,Gwałtowny wybuch rzuca cię o ścianę. Czy udało ci się dotrzeć do pomieszczenia gdzie jest łóżko z pasami?
+Eventexplode.text,Gwałtowny wybuch rzuca cię o ścianę. Czy udało ci się dotrzeć do pomieszczenia, gdzie znajdywało się łóżko z pasami?
 Eventexplode.button1,Tak
 Eventexplode.button2,Nie
-Eventall_dead.text,Koniec. Wszyscy nie żyją
+Eventall_dead.text,Koniec. \n\nWszyscy nie żyją.
 Eventall_dead.button1,Kontynuuj
-Tokenblock.text,Przejście jest zablokowane
+Tokenblock.text,Przejście jest zablokowane.
 Tokenblock.button1,Kontynuuj
 Eventafter_explode.text,Udało ci się przeżyć wybuch. Przejście jest całkowicie zablokowane.
 Eventafter_explode.button1,Kontynuuj
-Eventpast_end_john.text,Masz przeczucie, że lepiej będzie jak wyjdziecie stąd jak najszybciej się da. Słyszysz jakiś dziwny dźwięk, po plecach przechodzą ci ciarki. Każdy Badacz otrzymuje 1 zakrytą kartę Przerażenia.
+Eventpast_end_john.text,Masz przeczucie, że lepiej będzie jak wyjdziecie stąd jak najszybciej się da. Słyszysz jakiś dziwny dźwięk, po plecach przechodzą ci ciarki.\n\n(Każdy Badacz otrzymuje 1 zakrytą kartę Przerażenia.)
 Eventpast_end_john.button1,Kontynuuj
 Eventpast_end_john_1.button1,Kontynuuj
-Eventpast_end_john_1.text,Słyszysz narastający huk dochodzący z tunelu na wschodzie. Czujesz narastające przerażenie. Każdy Badacz otrzymuje 1 zakrytą kartę Przerażenia.
-Eventpast_end_john_2.button1,Przycisk1
+Eventpast_end_john_1.text,Słyszysz narastający huk dochodzący ze wschodniej części tunelu. Czujesz narastające przerażenie.\n\n(Każdy Badacz otrzymuje 1 zakrytą kartę Przerażenia)
+Eventpast_end_john_2.button1,Kontynuuj
 Eventpast_end_john_2.text,W dole tunelu pojawia się jakaś ogromna, zakapturzona postać.
-Eventpast_end_john_3.text,Posta wydaje z siebie jakieś dziwne dźwięki, jakby to był jakiś nieznany język. Zaczyna iść wzdłuż korytarza.
+Eventpast_end_john_3.text,Postać wydaje z siebie jakieś dziwne dźwięki, jakby jakiś nieznany język. Zaczyna iść wzdłuż korytarza w twoim kierunku.
 Eventpast_end_john_3.button1,Kontynuuj
-Eventspawndagon.button1,Przycisk1
-Eventpast_end_john_4.text,Wielka kula ognia przelatuje przez korytarz.
+Eventspawndagon.button1,Kontynuuj
+Eventpast_end_john_4.text,Postać ze swoich rąk wypuszcza wielką kulę ognia i rzuca ją w twoim kierunku. Ledwo unikasz zderzenia z zagrożeniem czując jednak jego palący żar na swojej skórze. 
 Eventpast_end_john_4.button1,Kontynuuj
-Eventpast_ednding_middle_john.text,Z głębi tunelu słyszysz jakieś krzyki. Szata potwora zapala się od ognia. Wszystko zaczyna palić się jak pochodnia. Ogień doszedł do lontu i za chwile wszystko wybuchnie. Macie ostatnią szansę na ucieczkę.
+Eventpast_ednding_middle_john.text,Za swoimi plecami z głębi tunelu słyszysz przeraźliwy krzyk. Szata potwora zapala się od ognia. Wszystko zaczyna palić się jak pochodnia. Ogień za moment dojdzie do lontu, a wszystko wybuchnie!\n\n(Macie ostatnią szansę na ucieczkę)
 Eventpast_ednding_middle_john.button1,Kontynuuj
 Eventend_game_question_john.button1,Tak
 Eventend_game_all_without_john.text,Wychodzicie z kopalni. Nie udało wam się rozwiązać tajemnicy morderstwa chłopca. \n\n Często o nim myślisz leżąc i patrząc przez zakratowane okno sanatorium w Arkham.
 Tokenpast_papers.text,Stos gazet.
 Tokenpast_papers.button1,({action}) Przeczytaj
-Eventpast_newspaper_president.button1,Czytaj inną
-Eventpast_newspaper_boy.text,26 Września 1901 (czwartek). To już 7 zaginięcie dziecka w przeciągu ostatnich 3 miesięcy. Poszukiwany chłopiec to Evan McCormic, lat 10, syn farmera. Nie wrócił do domu po pracy przy zbieraniu kukurydzy. Władze miasta są zaniepokojone ostatnimi zniknięciami. Szeryf Ratman wyznaczył nagrodę w wysokości 500$ za znalezienie chłopca. Lokalna grupa baptystów organizuje wieczorem 20 września spotkanie podczas którego będzie można wesprzeć rodzinę zaginionego chłopca.\n\n(Otrzymujesz 2 {clue})
-Eventpast_newspaper_president.text,29 Października 1901r (środa). Prezydent William McKinley's postrzelony. Podczas spotkania został postrzelony przez Leona Czołgosza, Amerykanina polskiego pochodzenia, który uważał, że McKinley jest winny powszechnej niesprawiedliwości społecznej. Prezydent otrzymał dwa strzały w brzuch i pierś i został szybko przeniesiony do pobliskiego szpitala. Po opatrzeniu rany brzucha, lekarze mają nadzieję że McKinley wyzdrowieje..
-Eventpast_newspaper_boy.button1,Czytaj inną
+Eventpast_newspaper_president.button1,Czytaj następną gazetę.
+Eventpast_newspaper_boy.text,26 Września 1901 (czwartek). To już siódme zaginięcie dziecka w przeciągu ostatnich 3 miesięcy.\nPoszukiwany chłopiec to Evan McCormic, lat 10, syn farmera. Nie wrócił do domu po pracy przy zbieraniu kukurydzy.\nWładze miasta są zaniepokojone ostatnimi zniknięciami. Szeryf Ratman wyznaczył nagrodę w wysokości $500 za znalezienie chłopca.\nLokalna grupa baptystów organizuje wieczorem 20 września spotkanie, podczas którego będzie można wesprzeć rodzinę zaginionego chłopca.\n\n(Otrzymujesz 2 {clue})
+Eventpast_newspaper_president.text,29 Października 1901r (środa). Prezydent William McKinley's postrzelony.\nPodczas spotkania został postrzelony przez Leona Czołgosza, Amerykanina polskiego pochodzenia, który uważał, że McKinley jest winny powszechnej niesprawiedliwości społecznej.\nPrezydent otrzymał dwa strzały w brzuch i pierś i został szybko przeniesiony do pobliskiego szpitala. Po opatrzeniu rany brzucha, lekarze mają nadzieję, że McKinley wyzdrowieje..
+Eventpast_newspaper_boy.button1,Czytaj inną gazetę.
 Eventpast_newspaper_menu.text,Wybierz
 Eventpast_newspaper_menu.button1,Prezydent postrzelony...
 Eventpast_newspaper_menu.button2,Zaginione dziecko...
 Eventpast_newspaper_menu.button3,Koniec świata...
-Eventpast_newspaper_end_of_world.text,"Rosną napięcia społeczne w związku z przełomem stuleci. Pastor tutejszego kościoła baptystów namawia wszystkich aby porzucili swoje grzechy i oddali to co dla nich najważniejsze bogu. <i>""Zbliża się dzień sądu ostatecznego, kto tego nie rozumie zginie w ogniu piekielnym..""</i> - powiedział pastor Carl Panzram."
+Eventpast_newspaper_end_of_world.text,"Rosną napięcia społeczne w związku z przełomem stuleci. \nPastor tutejszego kościoła baptystów namawia wszystkich, aby porzucili swoje grzechy i oddali to co dla nich najważniejsze bogu. <i>""Zbliża się dzień sądu ostatecznego! Kto tego nie rozumie, zginie w ogniu piekielnym...""</i> - powiedział pastor Carl Panzram."
 Eventpast_newspaper_end_of_world.button1,Czytaj dalej
-Tokenopen_secret_to_church.text,Widzisz świeżo usypaną ziemię i ślady butów dookoła. ({observation})
+Tokenopen_secret_to_church.text,Widzisz świeżo usypaną ziemię i ślady butów dookoła.\n\nTest obserwacji {observation}.
 Tokenopen_secret_to_church.button1,Kontynuuj
-Eventsecret_to_church_reveal.text,Ze zdumieniem odkrywasz klapę, która prowadzi do ciemnego tunelu
+Eventsecret_to_church_reveal.text,Ze zdumieniem odkrywasz klapę, która prowadzi do ciemnego tunelu.
 Eventsecret_to_church_reveal.button1,Kontynuuj
 Tokentunel_to_church.text,Wejście do tunelu.
 Tokentunel_to_church.button1,({action}) Wejdź
 Eventpast_tunel_end.text,Tunel biegnie jeszcze kilka metrów na wschód. Po lewej stronie widzisz przejście zakryte kamieniami i zabite deskami. Na końcu tunelu są drzwi. \n\n (Umieść: {c:Tilepast_tunel_end} na planszy)
 Eventpast_tunel_end.button1,Kontynuuj
-Tokenshow_blocked_doors.text,Zabite deskami przejście. Gdyby tylko mieć coś żeby podważyć te deski..
+Tokenshow_blocked_doors.text,Zabite deskami przejście. Gdybyście tylko mieli coś żeby podważyć te deski..
 Tokenshow_blocked_doors.button1,Kontynuuj
-Eventopen_blocked_doors.text,Wygląda na to, że kilofem będzie dało się otworzyć to przejście
-Eventopen_blocked_doors.button1,({action}) Otwórz przejście kilofem
-Eventopen_blocked_doors.button2,Nie mam kilofa
-Eventreveal_blocked_room.text,Ściana zrobiona z desek i kamieni się zawala ukazując małe ciemne pomieszczenie. Jest w nim dużo cuchnących beczek i górniczych narzędzi. Z boku dostrzegasz skrzynię. \n\n (Umieść: {c:Tilesecret_room} na planszy)
+Eventopen_blocked_doors.text,Wygląda na to, że kilofem może udać się otworzyć to przejście!
+Eventopen_blocked_doors.button1,({action}) Otwórz przejście kilofem.
+Eventopen_blocked_doors.button2,Nie posiadam kilofa.
+Eventreveal_blocked_room.text,Ściana zrobiona z desek i kamieni zawala się ukazując małe ciemne pomieszczenie. Jest w nim dużo cuchnących beczek i górniczych narzędzi. Z boku dostrzegasz skrzynię. \n\n (Umieść: {c:Tilesecret_room} na planszy)
 Eventreveal_blocked_room.button1,Kontynuuj
 Tokenshotgun_chest.text,Widzisz dużą, solidnie zbudowaną metalową skrzynię. Jest zamknięta na zamek szyfrowy.
-Tokenshotgun_chest.button1,({action}) Spróbuj otworzyć
-Eventspawn_monster_stairs.text,Czytanie gazety przerywają kroki. Przez drzwi z kierunku wschodniego wchodzi postać. Wygląda na bardzo zaskoczoną.
-Eventtake_shotgun.text,Skrzynia się otwiera i w środku widzisz strzelbę.  \n\n (Otrzymujesz {c:QItemshot_gun})
+Tokenshotgun_chest.button1,({action}) Spróbuj otworzyć.
+Eventspawn_monster_stairs.text,Czytanie gazety przerywają kroki. Przez drzwi z kierunku wschodniego wchodzi zakapturzona postać. Wygląda na bardzo zaskoczoną.
+Eventtake_shotgun.text,Skrzynia się otwiera i w środku widzisz strzelbę.  \n\n (Otrzymujesz {c:QItemshot_gun} Przedmiot powszechny)
 Puzzleopen_chest.button1,Sprawdź
 Eventtake_shotgun.button1,Kontynuuj
-TokenMiddle_room.text,Widzisz małe, drewniane drzwi na końcu tunelu
+TokenMiddle_room.text,Widzisz małe, drewniane drzwi na końcu tunelu.
 TokenMiddle_room.button1,({action})Otwórz
 Eventopen_middle_door.text,Drzwi się otwierają z głośnym trzaskiem. Widzisz drewniane schody, które prowadzą w dół do dużego pomieszczenia. \n\n (Umieść: {c:Tilemieddle_room} na planszy)
 Eventopen_middle_door.button1,Kontynuuj
-Eventmiddle_room_show.text,Na dole, zaraz przy schodach są drzwi, a obok znajduje się stół z jakimiś przedmiotami.
+Eventmiddle_room_show.text,Na dole zaraz przy schodach są drzwi, a obok znajduje się stół z jakimiś przedmiotami.
 Eventmiddle_room_show.button1,Kontynuuj
 Tokendoor_to_secret_church.text,Drzwi, prowadzą na północ.
 Tokendoor_to_secret_church.button1,({action}) Otwórz
 Eventopen_room_to_secret_church.text,Drzwi się otwierają i widzisz pomieszczenie, które wygląda na przepompownię. Rury wystają ze ścian, a podłoga jest wilgotna. W powietrzu unosi się zapach pleśni i zgrzybiałego drewna. \n\n(Umieść: {c:Tilesecret_passage} na planszy)
 Eventopen_room_to_secret_church.button1,Kontynuuj
-Tokenitems_in_middle_room.text,Na stole leży kilka przedmiotów
+Tokenitems_in_middle_room.text,Na stole leży kilka przedmiotów.
 Tokenitems_in_middle_room.button1,({action}) Przeszukaj
-Eventitems_in_middle_room.text,"Na stole leży gruba książka. Otwierasz ją. Na pierwszej stronie jest napis: ""Dziennik prac 1850-1855. Kopalnia miedzi"" W środku są tabele z nazwiskami, datami i ilością wydobytego urobku.\n\n(Otrzymujesz {clue} oraz {c:QItemitem_in_middle_room})"
+Eventitems_in_middle_room.text,"Na stole leży gruba książka. Otwierasz ją. Na pierwszej stronie jest napis: ""Dziennik prac 1850-1855. Kopalnia miedzi"" W środku są tabele z nazwiskami, datami i ilością wydobytego urobku.\n\n(Otrzymujesz 1 {clue} oraz {c:QItemitem_in_middle_room} Przedmiot powszechny)"
 Eventitems_in_middle_room.button1,Kontynuuj
 Eventmiddle_room_show1.text,W dalszej części pokoju widzisz dwoje drzwi i stertę gazet przy ścianie.
 Eventmiddle_room_show1.button1,Kontynuuj
 Tokenenter_to_church_corridor.text,Drzwi prowadzące na wschód.
 Tokenenter_to_church_corridor.button1,({action}) Otwórz
-Eventcorridor_to_church_reveal.text,Drzwi się otwierają. Widzisz ładną klatkę schodową wyłożoną czerwonym dywanem. Strome schody prowadzą w górę, na końcu widać kolejne drzwi. \n\n (Umieść: {c:Tilestairs_up} na planszy)
+Eventcorridor_to_church_reveal.text,Drzwi się otwierają. Widzisz ładną klatkę schodową wyłożoną czerwonym dywanem. Strome schody prowadzą w górę. Na końcu widać kolejne drzwi. \n\n (Umieść: {c:Tilestairs_up} na planszy)
 Eventcorridor_to_church_reveal.button1,Kontynuuj
 Tokenpast_church_enter.text,Drewniane, zdobione drzwi.
 Tokenpast_church_enter.button1,({action}) Zbadaj
@@ -276,126 +276,126 @@ Eventaxe_room_reveal.button1,Kontynuuj
 Tokenpick_axe.text,Widzisz trzy metalowe pojemniki.
 Tokenpick_axe.button1,({action}) Przeszukaj
 Eventspawn_monster_stairs.button1,Kontynuuj
-Eventmonster_stairs_menu.text,Co się tu dzieje, jak się tu dostałeś, kim jesteś? - mężczyzna zarzuca cię gradem pytań
+Eventmonster_stairs_menu.text,"<i>Co się tu dzieje, jak się tu dostałeś, kim jesteś?</i> - mężczyzna zarzuca cię gradem pytań."
 Eventmonster_stairs_menu.button1,Zaatakuj
-Eventmonster_stairs_menu.button2,Jestem detektywem
-Eventmonster_stairs_menu.button3,Jestem górnikiem
-Eventmonster_stairs_menu.button4,Jestem z kościoła
-Eventaxe_take.text,Pojemniki wyglądają jak trumny. Są puste ale masz wrażenie, że to może się niedługo zmienić. Pomiędzy pojemnikami widzisz kilof. \n\n (Otrzymujesz {clue} oraz {c:QItemaxe})
+Eventmonster_stairs_menu.button2,Jestem detektywem.
+Eventmonster_stairs_menu.button3,Jestem górnikiem.
+Eventmonster_stairs_menu.button4,Jestem z kościoła.
+Eventaxe_take.text,Pojemniki wyglądają jak trumny. Są puste, ale masz wrażenie, że to może się niedługo zmienić. Pomiędzy pojemnikami widzisz kilof. \n\n (Otrzymujesz 1 {clue} oraz {c:QItemaxe} Przedmiot powszechny)
 Eventaxe_take.button1,Kontynuuj
-Eventpast_newspaper_end_of_world.button2,Czytaj inną
+Eventpast_newspaper_end_of_world.button2,Czytaj inną gazetę.
 Eventpast_newspaper_menu.button4,Anuluj
 Eventpast_newspaper_president.button2,Anuluj
 Eventpast_newspaper_boy.button2,Anuluj
-Spawnspawn_staits_monster.text,"Widzisz przed sobą postać, która zmieniła się w okropny sposób. ""Chyba znalazłem kolejną ofiarę na dzień przebłagania.."""
+Spawnspawn_staits_monster.text,"Widzisz przed sobą postać, która zmieniła się w okropny sposób. <i>""Chyba znalazłem kolejną ofiarę na dzień przebłagania...""</i>"
 Spawnspawn_staits_monster.button1,Kontynuuj
 Eventstaris_monster_defeat.text,Potwór umiera.
 Eventstaris_monster_defeat.button1,Kontynuuj
-Eventi_detective.text,Detektywem powiadasz? Zapewne chcesz wiedzieć kim ja jestem... - odpowiada człowiek, powoli podnosząc prawą rękę.
+Eventi_detective.text,"<i>""Detektywem powiadasz? Zapewne chcesz wiedzieć kim jestem...""</i> - odpowiada człowiek, powoli podnosząc prawą rękę."
 Eventi_detective.button1,Kontynuuj
-Eventi_miner_dynamite.button1,Daj mu dynamit (jeśli masz przy sobie)
-Eventi_miner_dynamite.button2,Nie mam
-Eventi_miner_dynamite.text,Ach tak.. przyniosłeś dynamit, o który cię nasz pastor poprosił?
-Eventgive_dynamite.text,Świetnie. Idę go zanieść pastorowi, a ty się stąd nie ruszaj
+Eventi_miner_dynamite.button1,[masz dynamit przy sobie] Daj mu dynamit
+Eventi_miner_dynamite.button2,Nie mam.
+Eventi_miner_dynamite.text,"<i>""Ach tak.. przyniosłeś dynamit, o który cię nasz pastor poprosił?""</i>"
+Eventgive_dynamite.text,"<i>""Świetnie. Idę go zanieść pastorowi, a ty się stąd nie ruszaj.""</i>"
 Eventgive_dynamite.button1,Kontynuuj
-Eventno_dynamite.text,Głupcze. Jesteś bezużyteczny jeśli nawet tak prostego zadania nie umiesz wykonać. Będę musiał sam tam iść... \n\n ..ale wcześniej...
+Eventno_dynamite.text,"<i>""Głupcze. Jesteś bezużyteczny, jeśli nawet tak prostego zadania nie umiesz wykonać. Będę musiał sam tam iść... \n\n ...ale wcześniej...""</i>"
 Eventno_dynamite.button1,Kontynuuj
 Event_dynamite_quest.button1,Kontynuuj
 Event_carl_ask_about_dynamite.button1,Kontynuuj
-Tokenminer_body.text,W rogu widzisz pochylającego się człowieka.Tokenminer_body.button1,Zagadaj
+Tokenminer_body.text,W rogu widzisz pochylającego się człowieka.
 Tokenminer_body.button1,Zagadaj
-Eventminer_body.text,Próbujesz coś powiedzieć do człowieka ale wydaje się, że cię nie słyszy. Podchodzisz do niego i lekko klepiesz go po ramieniu...
+Eventminer_body.text,Próbujesz coś powiedzieć do człowieka, ale wydaje się, że cię nie słyszy. Podchodzisz do niego i lekko klepiesz go po ramieniu...
 Eventminer_body.button1,Kontynuuj
-Eventminer_body_1.text,..z przerażeniem widzisz jak ciało osuwa się na ziemię. Głowa mężczyzny jest roztrzaskana przez kamień. \n\n (Otrzymujesz 1 kartę Przerażenia)
+Eventminer_body_1.text,...z przerażeniem widzisz jak ciało osuwa się na ziemię. Głowa mężczyzny jest roztrzaskana przez kamień. \n\n (Otrzymujesz 1 kartę Przerażenia)
 Eventminer_body_1.button1,Kontynuuj
-Eventminer_body_2.text,Domyślasz się, że górnik po coś się schylał i musiał zaczepić o wielki kamień, który mu spadł prosto na głowę. Niedaleko jego ręki znajdujesz {c:QItemcigarette} z zapałkami.
+Eventminer_body_2.text,Domyślasz się, że górnik po coś się schylał i musiał zaczepić o wielki kamień, który mu spadł prosto na głowę. Niedaleko jego ręki znajdujesz {c:QItemcigarette} Przedmiot powszechny z zapałkami.
 Eventminer_body_2.button1,Kontynuuj
 Tokenminer_body_empty.text,Ciało górnika.
 Tokenminer_body_empty.button1,Kontynuuj
-Eventchurch_reveal_from_doors.text,Przez dziurkę od klucza widzisz duże pomieszczenie, wydaje się znajome, jakbyś tu już kiedyś był. Wygląda na nowo wybudowany kościół. Na ławkach siedzą ludzie, przy ołtarzu stoi bardzo wysoki i dobrze zbudowany mężczyzna, a na ołtarzu.. próbujesz się przypatrzeć ale nie dasz rady z tej odległości. \n\n (Umieść: {c:Tilechurch} na planszy)
+Eventchurch_reveal_from_doors.text,Przez dziurkę od klucza widzisz duże pomieszczenie. Wydaje się znajome, jakbyś tu już kiedyś był. Wygląda na nowo wybudowany kościół. Na ławkach siedzą ludzie, przy ołtarzu stoi bardzo wysoki i dobrze zbudowany mężczyzna, a na ołtarzu... Próbujesz się przypatrzeć, ale nie dasz rady z tej odległości. \n\n (Umieść: {c:Tilechurch} na planszy)
 Eventchurch_reveal_from_doors.button1,Otwórz drzwi
-Tokenchurch_crowd.text,..wierni z uwagą słuchają kazania
+Tokenchurch_crowd.text,..wierni z uwagą słuchają kazania.
 Tokenchurch_crowd.button1,Kontynuuj
-Tokenchurch_crowd_1.text,..wierni z uwagą słuchają kazania
+Tokenchurch_crowd_1.text,..wierni z uwagą słuchają kazania.
 Tokenchurch_crowd_1.button1,Kontynuuj
 Eventchurch_reveal_from_doors.button2,Zaczekaj
-Eventopen_door_to_church.text,Drzwi się cicho otwierają i wchodzisz do środka. Słyszysz przemówienie pastora o końcu świata.
+Eventopen_door_to_church.text,Drzwi cicho się otwierają i wchodzisz do środka. Słyszysz przemówienie pastora o końcu świata.
 Eventopen_door_to_church.button1,Zaatakuj pastora
-Eventchurch_reveal_from_secret.text,Przechodzisz przez ciemny tunel, który pnie się do góry. Na końcu dochodzisz do drewnianej klapy, uchylasz ją lekko i przez szparę widzisz duże pomieszczenie, wydaje się znajome, jakbyś tu już kiedyś był. Wygląda na nowo wybudowany kościół. Na ławkach siedzą ludzie, przy ołtarzu stoi bardzo wysoki i dobrze zbudowany mężczyzna, a na ołtarzu.. próbujesz się przypatrzeć... ale widzisz tylko nogi. Wyglądają na nogi małego chłopca... wygląda na to, że ci ludzie są niebezpieczni \n\n (Umieść: {c:Tilechurch} na planszy)
+Eventchurch_reveal_from_secret.text,Przechodzisz przez ciemny tunel, który pnie się do góry. Na końcu dochodzisz do drewnianej klapy, uchylasz ją lekko i przez szparę widzisz duże pomieszczenie, wydaje się znajome, jakbyś tu już kiedyś był. Wygląda na nowo wybudowany kościół. Na ławkach siedzą ludzie, przy ołtarzu stoi bardzo wysoki i dobrze zbudowany mężczyzna, a na ołtarzu... Próbujesz się przypatrzeć, ale widzisz tylko nogi. Wyglądają na nogi małego chłopca... Wygląda na to, że ci ludzie są niebezpieczni.\n\n (Umieść: {c:Tilechurch} na planszy i otrzymujesz 1 {clue})
 Eventchurch_reveal_from_secret.button1,Kontynuuj
-Eventset_dynamite.text,To powinno ich zaskoczyć.. \n\n Podpalasz lont, wrzucasz przez szparę do kaplicy i uciekasz przez tunel.
+Eventset_dynamite.text,To powinno ich zaskoczyć... \n\n Podpalasz lont, wrzucasz przez szparę do kaplicy i uciekasz przez tunel.
 Eventset_dynamite.button1,Kontynuuj
 Tokenevan_body.text,Ciało chłopca. Ma nadpaloną głowę.
 Tokenevan_body.button1,({action}) Zbadaj
-Eventchurch_explode.text,Eksplozja!! \n\n Wszyscy Badacze na polu {c:Tilechurch} otrzymują obrażenia od dynamitu.
+Eventchurch_explode.text,Eksplozja!! \n\n Wszyscy Badacze na polu {c:Tilechurch} otrzymują 2 obrażenia od dynamitu.
 Eventchurch_explode.button1,Kontynuuj
-Eventdynamite_from_body.text,Obok ciała znajdujesz
+Eventdynamite_from_body.text,Obok ciała znajdujesz...
 Eventdynamite_from_body.button1,Kontynuuj
 Eventdynamite_question.text,Czy podłożyć dynamit?
-Eventdynamite_question.button1,({action})Tak (mam dynamit przy sobie)
-Eventdynamite_question.button2,Nie, wróć tunelem
+Eventdynamite_question.button1,[mam dynamit przy sobie] ({action}) Tak
+Eventdynamite_question.button2,Nie, zawróć
 Tokenopen_secret_to_church.button2,Porażka
-Eventnothing.text,Nic tu ciekawego nie ma
+Eventnothing.text,Nic tu ciekawego nie ma.
 Eventnothing.button1,Kontynuuj
-Eventgo_back_from_church.text,Wracasz przez tunel
+Eventgo_back_from_church.text,Wracasz przez tunel.
 Eventgo_back_from_church.button1,Kontynuuj
-UI1.uitext,Jest 1 października 1920 roku. Twoja znajoma zaprasza cię na spotkanie w pobliskim kościele baptystów. Przez telefon wspomniała, że to ważne, a w jej głosie wyczułeś niepokój. Domyślasz się, że chodzi o zaginięcie jej syna Johna, pisały o tym gazety. Wygląda na to, że jeszcze się nie odnalazł...\n\nPo krótkiej podróży ze swojego biura docierasz przed stary drewniany kościół. Jest mały, o prostych kształtach z wąskimi wysokimi oknami. Część kościoła styka się z pobliską skalną górą. Słyszałeś, że kiedyś wydobywano tu miedź. Kilkanaście lat temu część kościoła spłonęła w pożarze. Został on odbudowany, jednak nie odzyskał dawnego blasku. Różne dziwne legendy krążą o tym miejscu. Podobno jest nawiedzone odkąd podczas jednego z kazań kontrowersyjnego pastora wybuchł pożar. Wielu miejscowych zginęło, ale samego pastora nigdy się nie odnaleziono; ani żywego, ani martwego.
+UI1.uitext,Jest 1 października 1920 roku.\n\nTwoja znajoma zaprosiła cię na spotkanie w pobliskim kościele baptystów. Przez telefon wspomniała, że to ważne. W jej głosie wyczułeś niepokój. Prawdopodobnie chodzi o zaginięcie jej syna Johna. Niedawno pisały o tym gazety. Wygląda na to, że jeszcze się nie odnalazł...\n\nPo krótkiej podróży ze swojego biura docierasz w okolice pobliskiej góry. Słyszałeś, że kiedyś w okolicy wydobywano miedź. Przyjaciółka chciała spotkać się z tobą w pobliskim małym drewnianym kościele znajdującym się u jej podnóża.\n\nKościół ma swoje lata świetności już za sobą. Kilkanaście lat temu część kościoła spłonęła w pożarze. Został on odbudowany i choć widać, że zadbano o odtworzenie drobnych detali w postaci prostych kształtów z wąskimi wysokimi oknami, to jednak nie odzyskał on swojego dawnego blasku.\n\n Po okolicach krążą różne dziwne legendy krążą o tym miejscu. Podobno jest nawiedzone odkąd podczas jednego z kazań kontrowersyjnego pastora wybuchł pożar. Wielu miejscowych zginęło, ale samego pastora nigdy nie odnaleziono; ani żywego, ani martwego.
 UI0.button1,Kontynuuj
 Eventstart_event.text,Wchodzisz do kościoła. Jest dość stary i zniszczony. Widać ślady dawnego pożaru, który miał tu miejsce. \n\n (Umieść: {c:Tilechurch} na planszy)
 Eventstart_event.button1,Kontynuuj
-Eventstart_event_1.text,W ławce siedzi twoja znajoma. Wygląda na bardzo smutną. Modli się.
+Eventstart_event_1.text,W ławce siedzi twoja przyjaciółka. Wygląda na bardzo smutną. Modli się.
 Eventstart_event_1.button1,Kontynuuj
 Eventstart_event_2.text,Na kontuarze znajduje się tabliczka z napisem, którego z tej odległości nie jesteś w stanie odczytać.
 Eventstart_event_2.button1,Kontynuuj
 Eventstart_event_3.text,Z tyłu kościoła jest stara, ładnie zdobiona, drewniana półka z książkami.
 Eventstart_event_3.button1,Kontynuuj
 Tokenfuture_doors_to_corridor.text,Duże, ładnie zdobione drzwi.
-Tokenfuture_doors_to_corridor.button1,{action} Otwórz
-Tokenfuture_exit.text,Wyjście.
-Tokenfuture_exit.button1,{action} Idź na miejsce zbrodni
+Tokenfuture_doors_to_corridor.button1,({action}) Otwórz
+Tokenfuture_exit.text,Wyjście
+Tokenfuture_exit.button1,({action}) Idź na miejsce zbrodni.
 Eventstart_event_4.text,Umieść Badaczy przy wejściu.
 Eventstart_event_4.button1,Kontynuuj
 Eventstart_event_5.text,Słyszysz jak drzwi się za tobą zamykają z głuchym trzaskiem.
 Eventstart_event_5.button1,Kontynuuj
 Tokenfriend.text,Twoja znajoma. Julie Mayer.
-Tokenfriend.button1,{action} Porozmawiaj
+Tokenfriend.button1,({action}) Porozmawiaj
 Tokeninfo_table.text,Napis na kontuarze.
-Tokeninfo_table.button1,{action} Zbadaj
-Eventinfo_table.text,Ku pamięci ofiar pożaru, który tu wybuchł w 12 grudnia 1901r. \n\n (Otrzymujesz {clue})
+Tokeninfo_table.button1,({action}) Zbadaj
+Eventinfo_table.text,Ku pamięci ofiar pożaru, który tu wybuchł w 12 grudnia 1901r. \n\n (Otrzymujesz 1 {clue})
 Eventinfo_table.button1,Kontynuuj
-Eventgo_to_crime_scene.text,Opuszczasz kościół i udajesz się na miejsce gdzie znaleziono ciało chłopca. Jest niedaleko, w pobliskim lesie.\n\n(Usuń wszystkie kafelki z planszy)
+Eventgo_to_crime_scene.text,Opuszczasz kościół i udajesz się na miejsce, gdzie znaleziono ciało chłopca. Jest niedaleko, w pobliskim lesie.\n\n(Usuń wszystkie kafelki z planszy)
 Eventgo_to_crime_scene.button1,Kontynuuj
 Eventfuture_corridor_reveal.text,Widzisz stare schody prowadzące w dół. Pokryte są czerwonym brudnym dywanem. Na końcu korytarza widzisz stare masywne drzwi.\n\n (Umieść {c:Tilestairs_up} na planszy})
 Eventfuture_corridor_reveal.button1,Kontynuuj
-Tokenfurue_book_shelf_interaction.button1,{action} Zbadaj
+Tokenfurue_book_shelf_interaction.button1,({action}) Zbadaj
 Tokenfurue_book_shelf_interaction.text,Półka z książkami.
-Eventfuture_books.text,"Jesteś lekko zdziwiony, że to nie egzemplarze Biblii lub innych religijnych książek. Przebiegasz wzrokiem po grzbietach i widzisz, że każda księga jest podpisana: ""Dziennik prac. Kopalnia miedzi"". Daty są od 1800 do 1900 roku. Brakuje dziennika z 1850-1855. W środku są tabele z nazwiskami, datami i ilością wydobytego urobku.\n\n(Otrzymujesz {clue})"
+Eventfuture_books.text,"Jesteś lekko zdziwiony, że to nie egzemplarze Biblii lub innych religijnych książek. Przebiegasz wzrokiem po grzbietach i widzisz, że każda księga jest podpisana: ""Dziennik prac. Kopalnia miedzi"". Daty są od 1800 do 1900 roku. Brakuje dziennika z 1850-1855. W środku są tabele z nazwiskami, datami i ilością wydobytego urobku.\n\n(Otrzymujesz 1 {clue})"
 Eventfuture_books.button1,Kontynuuj
-Eventjulie_talk.text,Cieszę się, że zdecydowałeś się mi pomóc. Jak zapewne wiesz, mój syn zaginął kilka dni temu. Policja jest bezradna, nie udało im się znaleźć żadnego tropu. Dowiedziałam się, że w pobliskim lesie znaleziono ciało jakiegoś chłopca. Na szczęście to nie był mój syn. Policja nie łączy tych dwóch spraw, ale zaczynam mieć bardzo złe przeczucia. Proszę idź tam. Może znajdziesz jakiś trop. Po drodze przeczytaj raport biegłego, udało mi się zdobyć kopię od lekarza, który badał zwłoki tego biednego chłopca. \n\n Powodzenia.  \n\n (Wszyscy Badacze otrzymują {clue})
+Eventjulie_talk.text,Cieszę się, że zdecydowałeś się mi pomóc. Jak zapewne wiesz, mój syn zaginął kilka dni temu. Policja jest bezradna, nie udało im się znaleźć żadnego tropu.\n Dowiedziałam się, że w pobliskim lesie znaleziono ciało jakiegoś chłopca. Na szczęście to nie był mój syn. Policja nie łączy tych dwóch spraw, ale zaczynam mieć bardzo złe przeczucia.\nProszę idź tam. Może znajdziesz jakiś trop. Po drodze przeczytaj raport biegłego. Udało mi się zdobyć kopię od lekarza, który badał zwłoki tego biednego chłopca.\nPowodzenia...\n\n (Wszyscy Badacze otrzymują 1 {clue})
 Eventjulie_talk.button1,Kontynuuj
 Eventjulie_talk_1.text,Kobieta wstaje. Ociera chusteczką oczy i wychodzi przez drzwi.
 Eventjulie_talk_1.button1,Kontynuuj
 EventSTART_GAME.button1,Kontynuuj
 Eventui_open.button1,Kontynuuj
-UI2.button1,Przycisk1
+UI2.button1,Kontynuuj
 EventSTART_GAME.text,Badacze zaczynają bez żadnych wskazówek.
 Eventend_game_03_alone.text,Wychodzisz z kopalni. Twoi przyjaciele nigdy się nie znaleźli chociaż poświęciłeś na ich szukanie wiele miesięcy. Nie udało ci się także rozwiązać tajemnicy zaginięcia chłopca. Do końca życia sobie nie wybaczyłeś tego, że ich tam zostawiłeś.
 Eventpast_dynamite.button3,Anuluj
 Eventopen_door_to_church.button2,Posłuchaj kazania
-Eventchurch_event_1.text,"...niec świata nadchodzi. Sąd ostateczny się zbliża - głośno mówi pastor z charakterystyczną u kaznodziei pewnością i agresją. ""Dowód na to widzicie przed sobą."" - ludzie wyciągają głowy żeby lepiej widzieć, niektórzy głośno wzdychają, jedna kobieta zaczyna płakać.. ""To, oto dziecko, ofiara świata i demonów musi ponieść ofiarę razem z nami!"" - krzyczy pastor. ""Ejmen"" - chórem odpowiadają wierni."""
+Eventchurch_event_1.text,"<i>""...koniec świata nadchodzi. Sąd ostateczny się zbliża""</i> - głośno mówi pastor z charakterystyczną u kaznodziei pewnością i agresją. <i>""Dowód na to widzicie przed sobą.""</i> - ludzie wyciągają głowy żeby lepiej widzieć, niektórzy głośno wzdychają, jedna kobieta zaczyna płakać.. <i>""To, oto dziecko, ofiara świata i demonów musi ponieść ofiarę razem z nami!""</i> - krzyczy pastor. <i>""Ejmen""</i> - chórem odpowiadają wierni."""
 Eventchurch_event_1.button1,Kontynuuj
 Tokenevan_alive_questionmark.button1,({action}) Zbadaj
-Tokenevan_alive.text,Chłopiec leży nieprzytomny
+Tokenevan_alive.text,Chłopiec leży nieprzytomny.
 Eventevan_alive_menu.text,"Z przerażeniem stwierdzasz, że ten chłopiec wygląda identycznie jak ten którego znaleźli policjanci, z tą różnicą, że żyje i nie ma obrażeń głowy. ""Co tu się dzieje?"" - cicho wyszeptujesz. \n\n (Otrzymujesz 1 zakrytą kartę Przerażenia)"
 Eventevan_alive_menu.button1,Kontynuuj
 Tokenevan_alive_questionmark.text,Dziecko leżące na kamiennym ołtarzu.
 Tokenevan_alive.button1,Kontynuuj
 Tokencarl.text,Pastor przemawia... Jest wysoki i muskularny, bije od niego pewność siebie i groza. Lepiej mu nie przeszkadzać.
 Tokencarl.button1,({action}) Zaatakuj
-Eventchurch_event_2.text,...świat jest zepsuty do szpiku kości! Gwałty, morderstwa. Nasz Pan się zbliża! Ajmen! - krzyczy pastor. \n\n Cała ta sytuacja coraz bardziej cię niepokoi, gorączkowo myślisz o tym jak z tego wybrnąć. Może da się jakoś odwrócić ich uwagę...
+Eventchurch_event_2.text,"<i>""...świat jest zepsuty do szpiku kości! Gwałty, morderstwa. Nasz Pan się zbliża! Ajmen!""</i> - krzyczy pastor. \n\n Cała ta sytuacja coraz bardziej cię niepokoi, gorączkowo myślisz o tym jak z tego wybrnąć. Może da się jakoś odwrócić ich uwagę..."
 Eventchurch_event_2.button1,Kontynuuj
 Event_body_raport.button1,Kontynuuj
-Event_carl_event.text,Ogromna eksplozja powaliła wszystkich zebranych w kaplicy. Nie wiadomo czy ktoś przeżył... \n\n Po chwili gdy uporczywy pisk w twoich uszach zaczyna się zmniejszać słyszysz, że w rumowisku ławek i ciał coś się rusza.
+Event_carl_event.text,Ogromna eksplozja powaliła wszystkich zebranych w kaplicy. Nie wiadomo, czy ktoś przeżył... \n\n Po chwili, gdy uporczywy pisk w twoich uszach zaczyna się zmniejszać słyszysz, że w rumowisku ławek i ciał coś się rusza.
 Event_body_raport.text,Z raportu koronera wynika, że chłopiec zmarł na skutek uszkodzenia przez wysoką temperaturę części potylicznej czaszki. Chłopiec był ubrany w strój, który przypomina te z czasów początku 20 wieku. Wiek chłopca to ok. 10 lat. Tożsamość martwego chłopca nie została potwierdzona.
 Event_carl_event.button1,Kontynuuj
 Tokendebris.text,Rumowisko z ławek i ciał.
@@ -403,16 +403,16 @@ Tokendebris.button1,Kontynuuj
 Tokenderbis_1.text,Rumowisko z ławek i ciał.
 Tokenderbis_1.button1,Kontynuuj
 Tokencarl_body.text,Pastor, wydaje się ledwo żywy..
-Tokencarl_body.button1,Zaatakuj ({action})
+Tokencarl_body.button1,({action}) Zaatakuj 
 Event_evan_body.text,Z przerażeniem zdajesz sobie sprawę, że to jest ten sam chłopiec, którym czytałeś w raporcie koronera, ma to samo  ubranie i takie same obrażenia. Twój umysł nie jest w stanie tego zrozumieć.\n\n (Otrzymujesz 2 zakryte karty Przerażenia)
 Event_evan_body.button1,Kontynuuj
-Event_carl_event_1.text,Pastor mimo, że otrzymał ogromne obrażenia powoli wstaje, a jego ciało się zmienia... słyszysz przerażający krzyk przemiany w potwora. Wszyscy Badacze na polu {c:Tilechurch} otrzymują 1 kartę Przerażenia.
+Event_carl_event_1.text,Pastor mimo, że otrzymał ogromne obrażenia powoli wstaje, a jego ciało się zmienia... słyszysz przerażający krzyk przemiany w potwora.\n\n(Wszyscy Badacze na polu {c:Tilechurch} otrzymują 1 kartę Przerażenia)
 Event_carl_event_1.button1,Kontynuuj
-Spawn_carl_monster.text,mogliście zostać w swoich czasach..
+Spawn_carl_monster.text,Mogliście zostać w swoich czasach...
 Spawn_carl_monster.button1,Kontynuuj
-Token_carl_monster.text,...mogliście zostać w swoich czasach
+Token_carl_monster.text,...mogliście zostać w swoich czasach.
 Token_carl_monster.button1,Kontynuuj
-Event_carl_monster_dead.text,Potwór ginie, a raczej rozpływa się w powietrzu. Na ziemi zostają jego poszarpane ubrania i srebrny klucz. \n\n (Otrzymujesz {c:QItem_silver_key})
+Event_carl_monster_dead.text,Potwór ginie, a raczej rozpływa się w powietrzu. Na ziemi zostają jego poszarpane ubrania i srebrny klucz. \n\n (Otrzymujesz {c:QItem_silver_key} Przedmiot unikatowy)
 Event_carl_monster_dead.button1,Kontynuuj
 Event_silver_key.text,Srebrny klucz
 Event_silver_key.button1,Kontynuuj
@@ -420,50 +420,51 @@ Event_dynamite_inventory.text,Dynamit, można nim coś wysadzić.
 Event_dynamite_inventory.button1,Kontynuuj
 Event_carl_run.text,Nachodzi was przeczucie, że trzeba jak najszybciej opuścić to miejsce.
 Event_carl_run.button1,Kontynuuj
-Event_carl_run_1.text,Carl nagle materializuje się na ołtarzu...
+Event_carl_run_1.text,Carl nagle materializuje się przed ołtarzem...
 Event_carl_run_1.button1,Kontynuuj
 Event_carl_run_2.text,...zabiera ciało chłopca i ucieka w stronę kopalni...
 Event_carl_run_2.button1,Kontynuuj
 Event_lamp.button1,Kontynuuj
-Event_lamp.text,{c:QItemlamp}
-Eventchurch_event_3.text,Dzisiaj złożymy wielką ofiarę aby przebłagać naszego pana. Musimy poświęcić to co dla nas najważniejsze, dlatego każdy z was... pastor mówi podniesionym głosem rozglądając się po kościele, nagle urywa zdanie gdy dostrzega ciebie.
+Event_lamp.text,Weź {c:QItemlamp} Przedmiot powszechny
+Eventchurch_event_3.text,"<i>""Dzisiaj złożymy wielką ofiarę, aby przebłagać naszego Pana. Musimy poświęcić to co dla nas najważniejsze, dlatego każdy z was...""</i>, pastor mówi podniesionym głosem rozglądając się po kościele, nagle urywa zdanie, gdy dostrzega was."
 Eventchurch_event_3.button1,Kontynuuj
 Eventchurch_event_question.text,Kim jesteś?
 Eventchurch_event_question.button1,Kontynuuj
-Event_church_event_with_dynamite.text,To jeden z naszych, kazałem mu przynieść dynamit. Przyniosłeś?
-Event_church_event_with_dynamite.button1,Daj dynamit
+Event_church_event_with_dynamite.text,"<i>""To jeden z naszych, kazałem mu przynieść dynamit. Przyniosłeś?""</i>"
+Event_church_event_with_dynamite.button1,[Posiadasz dynami] Daj dynamit
 Event_church_event_with_dynamite.button2,Nie mam
-Eventchurch_event_give_dynamite.text,Świetnie, w takim razie możemy zacząć naszą ofiarę. Pastor bierze od ciebie dynamit.
+Eventchurch_event_give_dynamite.text,"<i>""Świetnie, w takim razie możemy zacząć naszą ofiarę.""</i> Pastor bierze od ciebie dynamit."
 Eventchurch_event_give_dynamite.button1,Kontynuuj
-Eventchurch_event_0.text,Wchodzisz do kaplicy. Z pewnością jest to kaplica, w której spotkaliście się z matką zaginionego Johna ale wygląda inaczej. Jest nowa, zadbana. Nie ma śladów po pożarze. Ale przecież to niemożliwe, czyżbyś zaczął tracić zmysły? Powoli przechodzisz obok ludzi, próbując nie zwracać na siebie uwagi. \n\n (Otrzymujesz 1 zakrytą kartę Przerażenia)
+Eventchurch_event_0.text,"Wchodzisz do kaplicy. Z pewnością jest to kaplica, w której spotkaliście się z matką zaginionego Johna, ale wygląda inaczej. Jest nowa, zadbana. Nie ma śladów po pożarze.\n<i>""Ale przecież to niemożliwe, czyżbyś zaczął tracić zmysły?""</i>, myśli kołaczą wam się w głowie.\nPowoli przechodzisz obok ludzi, próbując nie zwracać na siebie uwagi. \n\n (Otrzymujesz 1 zakrytą kartę Przerażenia)"
 Eventchurch_event_0.button1,Kontynuuj
 Token_carl_waiting_for_dynamite.text,Pastor przemawia..
-Event_dynamite_quest.text,"Ach.. z kościoła. Dobrze. - mężczyzna wydaje się zmieszany. ""W takim razie idź szybko znajdź tego górnika, którego pastor wysłał po dynamit i nam go przynieś.."" - po chwili zastanowienia dodaje ""dynamit nie górnika"". Po czym wraca skąd przyszedł."
-Event_carl_ask_about_dynamite.text,Niedawno zostałem przyjęty do kościoła - szybko zmyślasz odpowiedź.
-Token_carl_waiting_for_dynamite.button1,({action}) Daj mu dynamit
-Event_john_feel.text,"Patrzysz w przerażone oczy chłopca i pytasz jak się czuje: \n<i>""ja n-n-nie w-w-wiem, ch-chyba dobrze.. gdzie jest mama?""</i> \n\nChłopiec jest wychudzony i blady, pytasz o jego imię: <i>\n""Mam na imię J-john""</i>\n\nA więc to jest John, zaginiony chłopiec, którego szukasz.\n\n (Otrzymujesz {clue})"
+Event_dynamite_quest.text,"<i>""Ach.. z kościoła. Dobrze.""</i>- mężczyzna wydaje się zmieszany. <i>""W takim razie idź szybko znajdź tego górnika, którego pastor wysłał po dynamit i nam go przynieś..""</i> - po chwili zastanowienia dodaje <i>""dynamit nie górnika""</i>. Po czym wraca skąd przyszedł."
+Event_carl_ask_about_dynamite.text,"<i>""Niedawno zostałem przyjęty do kościoła""</i> - szybko zmyślasz odpowiedź."
+Token_carl_waiting_for_dynamite.button1,[Posiadasz dynamit] ({action}) Daj mu dynamit
+Event_john_feel.text,"Patrzysz w przerażone oczy chłopca i pytasz jak się czuje.\n<i>""Ja n-n-nie w-w-wiem, ch-chyba dobrze.. gdzie jest mama?""</i> \n\nChłopiec jest wychudzony i blady. Pytasz o jego imię.\n<i>""Mam na imię J-john.""</i>\n\nA więc to jest John, zaginiony chłopiec, którego szukasz.\n\n (Otrzymujesz 1 {clue})"
 Event_john_feel.button1,Kontynuuj
-Event_john_how_get_here.text,"Ciesząc się, że go odnalazłeś pytasz jak się tu znalazł:\n\n<i>""Ja... ja bawiłem się w lesie kiedy zobaczyłem tego człowieka. Był wysoki... ciągnął coś za sobą... zostawił t-t-to przed wejściem do kopalni w krzakach. Bałem się bardzo, ale mnie nie zauważył. Wszedłem do kopalni, bo nie chciałem, żeby mnie znalazł... Schowałem się w takiej kryjówce w ścianie, ale tam była dziura... Wpadłem w nią... a-aa potem tylko pamiętam ten pokój. Jestem tu już bardzo długo..."" </i>- widzisz jak oczy chłopca zachodzą łzami."
+Event_john_how_get_here.text,"Ciesząc się, że go odnalazłeś pytasz jak się tu znalazł.\n<i>""Ja... ja bawiłem się w lesie, kiedy zobaczyłem tego człowieka. Był wysoki... Ciągnął coś za sobą... Zostawił t-t-to przed wejściem do kopalni w krzakach. Bałem się bardzo, ale mnie nie zauważył. Wszedłem do kopalni, bo nie chciałem, żeby mnie znalazł... Schowałem się w takiej kryjówce w ścianie, ale tam była dziura... Wpadłem w nią... a-aa potem tylko pamiętam ten pokój. Jestem tu już bardzo długo..."" </i> - widzisz jak oczy chłopca zachodzą łzami."
 Event_john_how_get_here.button1,Kontynuuj
 Event_attack_carl_human.text,Bierzesz wielki metalowy stojak na świecę i z całej siły uderzasz pastora w głowę.
 Event_attack_carl_human.button1,Kontynuuj
 Event_spawn_minions.text,Z przerażeniem zauważasz, że reszta zgromadzonych też się zmienia..
 Event_spawn_minions.button1,Kontynuuj
 Spawnminion1.button1,Kontynuuj
-Spawnminion1.text,Ajmen.. ajmen.. ajmenn.. \n\n(Umieść: {c:Spawnminion1} na planszy)
+Spawnminion1.text,"<i>""Ajmen.. ajmen.. ajmenn..""</i>\n\n(Umieść: {c:Spawnminion1} na planszy)"
 Spawnminion_2.button1,Kontynuuj
-Spawnminion_2.text,Aaaajjjmeeeen!!!
+Spawnminion_2.text,"<i>""Aaaajjjmeeeen!!!""</i>"
 Token_carl_waiting_for_dynamite.button2,({action}) Zaatakuj
-Token_spell_book.button1,{action} Weź
+Token_spell_book.button1,({action}) Weź
 Event_slivering.button1,Kontynuuj
-Event_Machete.text,Oglądasz dokładnie kamienie szukając szczeliny, która umożliwiała by ci zobaczenie co jest po drugiej stronie. Po chwili dostrzegasz metalowy, zardzewiały przedmiot.\n\n (Otrzymujesz {c:QItemMachete})
+Event_Machete.text,Oglądasz dokładnie kamienie szukając szczeliny, która umożliwiała by ci zobaczenie co jest po drugiej stronie. Po chwili dostrzegasz metalowy, zardzewiały przedmiot.\n\n (Otrzymujesz {c:QItemMachete} Przedmiot powszechny)
 Token_spell_book.text,Widzisz książkę z dziwnymi symbolami oprawioną w skórę.
-Event_slivering.text,Otrzymujesz {c:QItemshriveling}.
+Event_slivering.text,Otrzymujesz Zaklęcie {c:QItemshriveling}.
 Event_Machete.button1,Kontynuuj
 Tokenend_of_tunel_1.text,Zawalony tunel.
 Tokenend_of_tunel_1.button1,Kontynuuj
-Spawncultist.text,Drzwi są otwarte. Przed chwilą ktoś nimi znokautował jednego z was. Zakapturzona postać wchodzi do pomieszczenia
-EventEvent_watch_from_past.text,"Oglądasz zegarek, wygląda dokładnie jak ten, który znalazłeś wcześniej przed kopalnią, tyle że jest dużo starszy i zniszczony. Ma dokładnie ten sam grawer z tyłu z napisem: ""dla Evana 1881"""
+Tokenend_of_tunel.button2,Porażka
+Spawncultist.text,Drzwi są otwarte. Przed chwilą ktoś nimi znokautował jednego z was. Zakapturzona postać wchodzi do pomieszczenia.
+EventEvent_watch_from_past.text,"Oglądasz zegarek. Wygląda dokładnie jak ten, który znalazłeś wcześniej przed kopalnią, tyle że jest dużo starszy i zniszczony. Ma dokładnie ten sam grawer z tyłu z napisem: ""dla Evana 1881""."
 EventEvent_watch_from_past.button1,Kontynuuj
 Tokendynamite_after_fail.button3,Anuluj
 EventTokenPastDoors1.text,W drugim, nieco większym pomieszczeniu są drzwi.
@@ -471,22 +472,22 @@ EventTokenPastDoors1.button1,Kontynuuj
 Eventpast_shelf_in_shelter0.text,Na końcu pokoju widzisz łóżko piętrowe.
 Eventpast_shelf_in_shelter0.button1,Kontynuuj
 EventToken_go_to_future.button1,Kontynuuj
-EventToken_torture_bed.text,Na środku pomieszczenia stoi skórzane łóżko z pasami.
 EventToken_go_to_future.text,Za twoimi plecami znajduje się przejście, z którego wypadłeś.
+EventToken_torture_bed.text,Na środku pomieszczenia stoi skórzane łóżko z pasami.
 EventToken_torture_bed.button1,Kontynuuj
 Token_church_doors_to_mine.text,Stare masywne drzwi.
-Token_church_doors_to_mine.button1,{action} Zbadaj
-Event_church_doors_to_mine_explore.text,Drzwi są drewniane, solidnie zrobione, spięte grubymi metalowymi pasami. Zamek w drzwiach jest duży i staroświecki. Naciskasz na klamkę ale drzwi są zamknięte. Próbujesz zobaczyć coś przez dziurę od klucza ale jest tam tylko ciemność, zapach stęchlizny i zbutwiałego drewna.\n\n(Otrzymujesz {clue})
+Token_church_doors_to_mine.button1,({action}) Zbadaj
+Event_church_doors_to_mine_explore.text,Drzwi są drewniane, solidnie zrobione, spięte grubymi metalowymi pasami. Zamek w drzwiach jest duży i staroświecki.\nNaciskasz na klamkę, ale drzwi są zamknięte. Próbujesz zobaczyć coś przez dziurę od klucza, ale jest tam tylko ciemność, zapach stęchlizny i zbutwiałego drewna.\n\n(Otrzymujesz 1 {clue})
 Event_church_doors_to_mine_explore.button1,Kontynuuj
 Token_church_doors_to_mine_static.text,Zamknięte masywne drzwi
 Token_church_doors_to_mine_static.button1,Kontynuuj
-Tokenfuture_books_doors_reveal.text,Postanawiasz jeszcze raz rzucić okiem na póki, masz przeczucie, że coś z nimi jest nie tak..
-Tokenfuture_books_doors_reveal.button1,{action} Zbadaj
-Eventfuture_books_doors_reveal_test.text,Wyciągasz książki na chybił trafił mając nadzieję, że znajdziesz coś interesującego. \nTest wiedzy {lore}.
+Tokenfuture_books_doors_reveal.text,Postanawiasz jeszcze raz rzucić okiem na póki. Masz przeczucie, że coś z nimi jest nie tak...
+Tokenfuture_books_doors_reveal.button1,({action}) Zbadaj
+Eventfuture_books_doors_reveal_test.text,Wyciągasz książki na chybił trafił mając nadzieję, że znajdziesz coś interesującego. \n\nTest wiedzy {lore}.
 Eventfuture_books_doors_reveal_test.button1,Kontynuuj
 Eventfuture_books_doors_reveal_test.button2,Kontynuuj
 Eventfuture_books_doors_reveal_test.button3,Anuluj
-Eventfuture_books_doors_reveal_success.text,Próbujesz wyciągnąć kolejną książkę, pociągasz ją w dół, słyszysz ciche kliknięcie i czujesz, że półka lekko się poruszyła. Po dokładniejszym zbadaniu dostrzegasz prowadnice na podłodze, które umożliwiają łatwe przesunięcie półki na bok. Ze zdziwieniem obserwujesz jak półka się przesuwa, a twoim oczom ukazują się ładnie zdobione drzwi.
+Eventfuture_books_doors_reveal_success.text,Próbujesz wyciągnąć kolejną książkę, pociągasz ją w dół, słyszysz ciche kliknięcie i czujesz, że półka lekko się poruszyła. Po dokładniejszym zbadaniu dostrzegasz prowadnice na podłodze, które umożliwiają łatwe przesunięcie półki na bok. Ze zdziwieniem obserwujesz, jak półka się przesuwa, a twoim oczom ukazują się ładnie zdobione drzwi.
 Eventfuture_books_doors_reveal_success.button1,Kontynuuj
 Tokenfurue_book_shelf_open.text,Półka z dziennikami urobku.
 Tokenfurue_book_shelf_open.button1,Kontynuuj
@@ -494,51 +495,50 @@ Eventfuture_books_doors_reveal_fail.text,Po krótkiej chwili, stwierdzasz że ni
 Eventfuture_books_doors_reveal_fail.button1,Kontynuuj
 Event_church_doors_to_mine_knife.text,Kierując się z powrotem na górę dostrzegasz coś metalowego wystającego spod dywanu. \n\n(Otrzymujesz {c:QItem_church_doors_to_mine_knife})
 Event_church_doors_to_mine_knife.button1,Kontynuuj
-Tokenend_of_tunel.button2,Porażka
-Eventend_of_tunel_fail.text,Oglądasz dokładnie rumowisko szukając szczeliny, która umożliwiała by ci zobaczenie co jest po drugiej stronie. Ostrożnie wyciągasz luźny kamień, niestety powoduje to małą lawinę, która spada w twoim kierunku. W ostatniej chwili się cofasz ale jeden z kamieni leci prosto na twoją głowę. \n\nOtrzymujesz 2 zakryte karty Obrażeń ({agility} zapobiega). 
+Eventend_of_tunel_fail.text,Oglądasz dokładnie rumowisko szukając szczeliny, która umożliwiała by ci zobaczenie co jest po drugiej stronie. Ostrożnie wyciągasz luźny kamień, niestety powoduje to małą lawinę, która spada w twoim kierunku. W ostatniej chwili się cofasz, ale jeden z kamieni leci prosto na twoją głowę. \n\n (Otrzymujesz 2 zakryte karty Obrażeń ({agility} zapobiega). 
 Eventend_of_tunel_fail.button1,Kontynuuj
-Tokenpast_doors1_blocked.text,Drzwi są bardzo solidnie zrobione, nie jesteś ich w żaden sposób otworzyć.
+Tokenpast_doors1_blocked.text,Drzwi są bardzo solidnie zrobione. Nie jesteś ich w żaden sposób otworzyć.
 Tokenpast_doors1_blocked.button1,Kontynuuj
-Eventpast_doors1_blocked.text,Drzwi są bardzo solidnie zrobione, nie jesteś ich w żaden sposób otworzyć.
+Eventpast_doors1_blocked.text,Drzwi są bardzo solidnie zrobione. Nie jesteś ich w żaden sposób otworzyć.
 Eventpast_doors1_blocked.button1,Kontynuuj
-Eventpast_end_game_alone0_place_invest.text,Po kilku minutach pozostali Badacze zaniepokojeni zniknięciem towarzysza zbierają się w pomieszczeniu gdzie ostatnio go widzieli.\n\n(Umieść pozostałych Badaczy na planszy)\n\n(Badacze odzyskują kontrolę nad swoimi postaciami)
+Eventpast_end_game_alone0_place_invest.text,Po kilku minutach pozostali Badacze zaniepokojeni zniknięciem towarzysza zbierają się w pomieszczeniu, gdzie ostatnio go widzieli.\n\n(Umieść pozostałych Badaczy na planszy. Badacze odzyskują kontrolę nad swoimi postaciami)
+Eventpast_end_game_alone0_place_invest.button1,Kontynuuj
 Tokenpast_end_game_alone0_place_invest.button1,Kontynuuj
 Eventtime_test.button2,Anuluj
 Eventtime_test_watch_trigger.text,Ze zdumieniem odkrywasz, że kręcąc bezelem zegarka wpływasz na układ symboli na pokrywie włazu. Nie masz pojęcia jakim cudem to działa, ale możesz spróbować różnych kombinacji.
-Eventtime_test_watch_trigger.button1,{action} Rozwiąż zagadkę
+Eventtime_test_watch_trigger.button1,({action}) Rozwiąż zagadkę
 Eventtime_test_watch_trigger.button2,Anuluj
 Eventtime_test_no_watch.button1,Kontynuuj
-Eventtime_test_no_watch.text,Pod śmieciami znajdujesz jakiś właz zrobiony ze zaśniedziałego metalu. Cały jest pokryty dziwnymi symbolami. Nie masz pojęcia co one znaczą, być może przeoczyłeś jakąś wskazówkę.
+Eventtime_test_no_watch.text,Pod śmieciami znajdujesz jakiś właz zrobiony ze zaśniedziałego metalu. Cały jest pokryty dziwnymi symbolami. Nie masz pojęcia co one znaczą. Być może przeoczyłeś jakąś wskazówkę.
 Eventgo_to_future_disapear.button1,Kontynuuj
-Eventpast_end_game_alone0_place_invest.button1,Kontynuuj
-EventEndgame_all_one_missing.text,Wychodzicie z kopalni. Mimo wielomiesięcznego śledztwa nie udaje wam się wyjaśnić śmierci znalezionego chłopca ani odnaleźć Johna. Co gorsze zaginiony Badacz nigdy się nie odnalazł. Do końca życia każdy z was się zastanawia co właściwie się stało tego deszczowego dnia kiedy zaczęliście śledztwo. Czy to w ogóle się wydarzyło naprawdę?
+EventEndgame_all_one_missing.text,Wychodzicie z kopalni. Mimo wielomiesięcznego śledztwa nie udaje wam się wyjaśnić śmierci znalezionego chłopca, ani odnaleźć Johna. Co gorsze zaginiony Badacz nigdy się nie odnalazł. Do końca życia każdy z was się zastanawia, co właściwie się stało tego deszczowego dnia, kiedy zaczęliście śledztwo. Czy to w ogóle się wydarzyło naprawdę?
 EventEndgame_all_one_missing.button1,Kontynuuj
 EventEND_GAME.text,Koniec Gry.\n\nTo jest jedno z kilku możliwych zakończeń.
 EventEND_GAME.button1,Kontynuuj
-Event_wakeup_in_john_room.text,Budzisz się w cuchnącym pokoju. Jak przez mgłę przypominasz sobie głosy i ludzi, którzy cię zabrali. Domyślasz się, że cię tu przenieśli. Powoli otwierasz oczy i rozglądasz się po pomieszczeniu.\n\n(Umieść: {c:Tilepast_boy_room})\n\n(Umieść Badacza, który wszedł przez przejście na planszy)
+Event_wakeup_in_john_room.text,Budzisz się w cuchnącym pokoju. Jak przez mgłę przypominasz sobie głosy i ludzi, którzy cię zabrali. Domyślasz się, że cię tu przenieśli. Powoli otwierasz oczy i rozglądasz się po pomieszczeniu.\n\n(Umieść: {c:Tilepast_boy_room}. Umieść Badacza, który wszedł przez przejście na planszy)
 Event_wakeup_in_john_room.button1,Kontynuuj
 Event_wakeup_in_john_room_john_spawn.text,W dalszej części pomieszczenia widzisz drewniane łóżko, na którym leży młody chłopak w wieku około 10 lat.
 Event_wakeup_in_john_room_john_spawn.button1,Kontynuuj
 Event_wakeup_in_john_room_doors.text,Do pokoju prowadzą solidne, metalowe drzwi.
 Event_wakeup_in_john_room_doors.button1,Kontynuuj
 Tokenpast_end_game_alone_pickaxe.text,Widzisz zardzewiały kilof oparty o ścianę. Rdza i brud sprawiają, że jest ledwo dostrzegalny w słabym świetle tunelu.
-Tokenpast_end_game_alone_pickaxe.button1,{action} Weź
+Tokenpast_end_game_alone_pickaxe.button1,({action}) Weź
 Eventpast_end_game_alone_pickaxe_take.text,Otrzymujesz {c:QItemaxe}.
 Eventpast_end_game_alone_pickaxe_take.button1,Kontynuuj
 Tokenend_of_tunel_destroyable.text,Przy pomocy kilofa możesz spróbować odkopać przejście.
 Tokenend_of_tunel_destroyable.button1,{action} Kontynuuj
 Tokenend_of_tunel_destroyable.button2,Porażka
-Eventend_of_tunel_destroyable_success.text,Z wielkim wysiłkiem udało ci się zrobić małe przejście na drugą stronę. Przez dziurę widzisz tunel niknący w ciemności.\n\n(Umieść: {c:Tilepast_mine_tuner_right})
+Eventend_of_tunel_destroyable_success.text,Z wielkim wysiłkiem udało ci się zrobić małe przejście na drugą stronę. Przez dziurę widzisz tunel niknący w ciemności.\n\n(Umieść: {c:Tilepast_mine_tuner_right} na planszy)
 Eventend_of_tunel_destroyable_success.button1,Kontynuuj
-Event_watch_ready_to_drop.text,"Oglądasz zegarek, jest zrobiony bardzo starannie, błyszczący metal jest dokładnie wypolerowany. Z tyłu jest grawer z napisem: ""dla Evana 1881"" Całkiem nieźle się trzyma jak na 40 letni zegarek. Na kopercie zegarka jest zamontowany ruchomy bezel, który jest pokryty dziwnymi symbolami.\n\nNaglę olśniewa cię zrozumienie, to jedyna szansa na ratunek. Masz nadzieję, że twoi towarzysze nie zawiodą.\n\n(Otrzymujesz {clue})"
-Event_watch_ready_to_drop.button1,{action} Wsuń zegarek pod drzwi
+Event_watch_ready_to_drop.text,"Oglądasz zegarek, jest zrobiony bardzo starannie, błyszczący metal jest dokładnie wypolerowany. Z tyłu jest grawer z napisem: ""dla Evana 1881"" Całkiem nieźle się trzyma jak na 40 letni zegarek. Na kopercie zegarka jest zamontowany ruchomy bezel, który jest pokryty dziwnymi symbolami.\n\nNaglę olśniewa cię zrozumienie, to jedyna szansa na ratunek. Masz nadzieję, że twoi towarzysze nie zawiodą.\n\n(Otrzymujesz 1 {clue})"
+Event_watch_ready_to_drop.button1,({action}) Wsuń zegarek pod drzwi.
 Event_watch_ready_to_drop.button2,Anuluj
 Event_go_past_with_old_watch.text,Tym razem nie ryzykujesz i czekasz na towarzyszy.
-Event_go_past_with_old_watch.button1,{action} Wejdźcie do przejścia razem
+Event_go_past_with_old_watch.button1,({action}) Wejdźcie do przejścia razem
 Event_go_past_with_old_watch.button2,Anuluj
-Event_go_past_with_old_watch1.button1,Kontynuuj
 Event_go_past_with_old_watch1.text,Lecisz chwile przez ciemność, czując zimny wiatr na twarzy.. 
-EventMythos_minior_trigger.text,W pomieszczeniu nagle robi się zimno, a ściany lekko drgają. Dreszcz przechodzi cię po plecach kiedy wyczuwasz dziwną aurę wokół. Wszyscy Badacze otrzymują 1 zakrytą kartę Przerażenia ({will} zapobiega).
+Event_go_past_with_old_watch1.button1,Kontynuuj
+EventMythos_minior_trigger.text,W pomieszczeniu nagle robi się zimno, a ściany lekko drgają. Dreszcz przechodzi cię po plecach, kiedy wyczuwasz dziwną aurę wokół.\n\n(Wszyscy Badacze otrzymują 1 zakrytą kartę Przerażenia ({will} zapobiega))
 EventMythos_minior_trigger.button1,Kontynuuj
 Event_drop_watch.text,Wsuwasz ostrożnie zegarek pod drzwi.\n\nPołóż przedmiot {c:QItem_watch_ready_to_drop} we wskazanym miejscu.
 Event_drop_watch.button1,Kontynuuj
@@ -546,15 +546,15 @@ Eventend_of_tunel_destroyable_door_reveal.text,Po prawej stronie widzisz metalow
 Eventend_of_tunel_destroyable_door_reveal.button1,Kontynuuj
 Token_time_respawn.text,Domyślasz się, że aby ponownie otworzyć przejście musisz użyć zegarka. 
 Token_time_respawn.button1,Kontynuuj
-Eventend_of_tunel_destroyable_fail0.text,Mimo usilnych prób nie udaje ci się zrobić przejścia. Kamienie są duże i zakleszczone ze sobą
+Eventend_of_tunel_destroyable_fail0.text,Mimo usilnych prób, nie udaje ci się zrobić przejścia. Kamienie są duże i zakleszczone ze sobą.
 Eventend_of_tunel_destroyable_fail0.button1,Kontynuuj
-Eventend_of_tunel_destroyable_fail1.text,Uderzasz z całych sił w skałę, kilof niefortunnie odbija się od dużego kamienia prosto w twoją głowę. \n\nOtrzymujesz 1 zakrytą kartę Obrażenia ({agility} zapobiega).
+Eventend_of_tunel_destroyable_fail1.text,Uderzasz z całych sił w skałę, a kilof niefortunnie odbija się od dużego kamienia prosto w twoją głowę. \n\n(Otrzymujesz 1 zakrytą kartę Obrażenia ({agility} zapobiega))
 Eventend_of_tunel_destroyable_fail1.button1,Kontynuuj
-Eventend_of_tunel_destroyable_fail2.text,Sfrustrowany ostatkiem sił uderzasz na oślep w kamienie. Cała konstrukcja niespodziewanie się zawala prosto na ciebie.\n\nOtrzymujesz 2 zakryte karty Obrażeń ({agility} zapobiega).\nNastępnie odkrywasz jedną kartę Obrażeń, kiedy sterta kamieni powala cię na ziemię.
+Eventend_of_tunel_destroyable_fail2.text,Sfrustrowany ostatkiem sił uderzasz na oślep w kamienie. Cała konstrukcja niespodziewanie się zawala prosto na ciebie.\n\n(Otrzymujesz 2 zakryte karty Obrażeń ({agility} zapobiega). Następnie odkrywasz jedną kartę Obrażeń, kiedy sterta kamieni powala cię na ziemię)
 Eventend_of_tunel_destroyable_fail2.button1,Kontynuuj
 Eventfriendfound.text,Z ulgą odkrywasz, że zaginiony towarzysz również się odnalazł.
 Eventfriendfound.button1,Kontynuuj
-Event_john_watch_help.text,"John patrzy się na ciebie przez chwilę ze zdziwioną miną i mówi w końcu: \n<i>""tam przed kopalnią koło tego... tego... c-chłopca widziałem zegarek... taki sam jak twój... czy to ten sam zegarek?</i>\n- chłopiec pyta trochę zawstydzony."
+Event_john_watch_help.text,"John patrzy się na ciebie przez chwilę ze zdziwioną miną i mówi w końcu: \n<i>""tam przed kopalnią koło tego... tego... c-chłopca widziałem zegarek... taki sam jak twój... czy to ten sam zegarek?</i> - chłopiec pyta trochę zawstydzony."
 Event_john_watch_help.button1,Kontynuuj
-Eventtorture_bed1.text,Skórzane łóżko z pasami. Wszystko wskazuje na to, że ktoś niedawno był tu przywiązany. Sądząc po śladach krwi, było to kilka godzin temu.\n\n (Otrzymujesz {clue})
+Eventtorture_bed1.text,Skórzane łóżko z pasami. Wszystko wskazuje na to, że ktoś niedawno był tu przywiązany. Sądząc po śladach krwi, było to kilka godzin temu.\n\n (Otrzymujesz 1 {clue})
 Eventtorture_bed1.button1,Kontynuuj


### PR DESCRIPTION
Unified order of locations' files.
Unified translations across PL and EN versions (EN was lacking some PL texts' changes made by zcaalock).
Corrected bigger and smaller mistakes in both versions.
Modified PL version a little in some places so, I think, it's better to read but I left the sense of the sentences. 